### PR TITLE
MOSIP-45284 - RAG Answer Quality Improvements + Claude Desktop Integration (Fine-Tuning & MCP Integration Changes)

### DIFF
--- a/MosipNexus/.env.example
+++ b/MosipNexus/.env.example
@@ -1,4 +1,7 @@
-# ── Required ───────────────────────────────────────────────────────────────────
+# ── Optional: Groq API key (server-side ingestion only) ────────────────────────
+# Used by the ingestion pipeline (thread summarizer). NOT used by the web app or
+# API — users provide their own LLM key via the Settings page (BYOK) or Claude
+# Desktop MCP integration.
 GROQ_API_KEY=gsk_your_key_here          # https://console.groq.com (free tier)
 
 # ── Optional: HuggingFace token (avoids rate-limiting on model downloads) ──────

--- a/MosipNexus/.gitignore
+++ b/MosipNexus/.gitignore
@@ -18,8 +18,9 @@ data/crawl_state.json
 data/mosip_confluence.json
 data/mosip_jira.json
 
-# ── pg_dump for team sharing — large binary, not for git ──────────────────────
+# ── pg_dump / zip exports — large binaries, not for git ──────────────────────
 nexus_vectors.dump
+nexus_vectors.zip
 
 # ── Virtual environment (managed at monorepo root) ────────────────────────────
 .venv/

--- a/MosipNexus/README.md
+++ b/MosipNexus/README.md
@@ -5,7 +5,7 @@ A production-grade RAG chatbot that answers MOSIP questions using **five knowled
 ## Documentation
 
 | Document | Audience | Location |
-|---|---|---|
+| --- | --- | --- |
 | [Developer Guide](docs/MOSIP_Nexus_Developer_Guide.docx) | Developers (zero GenAI background) | `docs/MOSIP_Nexus_Developer_Guide.docx` |
 | [Business Presentation](docs/MOSIP_Nexus_Presentation.pptx) | Stakeholders, managers, org leaders | `docs/MOSIP_Nexus_Presentation.pptx` |
 | [Rancher Deployment Guide](docs/MOSIP_Nexus_Rancher_Deployment_Guide.md) | Infrastructure / DevOps team | `docs/MOSIP_Nexus_Rancher_Deployment_Guide.md` |
@@ -15,7 +15,7 @@ A production-grade RAG chatbot that answers MOSIP questions using **five knowled
 ## Knowledge Base
 
 | Source | Chunks | Description |
-|---|---|---|
+| --- | --- | --- |
 | MOSIP Docs | 6,094 | All 449 pages from docs.mosip.io/1.2.0 |
 | Community Forum | 11,236 | Q&A threads from community.mosip.io (accepted answers prioritised) |
 | GitHub Issues | 2,513 | Closed issues from 86 MOSIP org repos |
@@ -31,7 +31,7 @@ A production-grade RAG chatbot that answers MOSIP questions using **five knowled
 ## Features
 
 | Feature | Details |
-|---|---|
+| --- | --- |
 | **Five knowledge sources** | Docs + Community + GitHub + Confluence + Code — all searchable in one query |
 | **Multilingual** | Ask in any language (Tamil, Hindi, French, Arabic, …); replies in the same language (≥95% confidence) |
 | **Chat memory** | Follow-up questions retain full conversation context |
@@ -40,51 +40,62 @@ A production-grade RAG chatbot that answers MOSIP questions using **five knowled
 | **Community intelligence** | `[ACCEPTED ANSWER]` posts and high-voted replies ranked higher |
 | **Confidence scoring** | 🟢 High / 🟡 Medium / 🔴 Low based on retrieval cosine distance |
 | **No hallucination guard** | LLM instructed to return "not available" when context is irrelevant |
+| **BYOK — Bring Your Own Key** | Users supply their own Groq / Anthropic / OpenAI API key via the Settings page. No server-side LLM cost for user queries. |
+| **Claude Desktop / MCP** | Connect Claude Desktop directly — it calls `search_mosip` for retrieval and uses your own Claude subscription for the LLM. Zero API cost to the app owner. |
+| **Query intelligence** | Automatic query classification: error-code format, environment-debug format, code-class format, or general. Each gets a specialised system prompt and retrieval strategy. |
+| **Hybrid retrieval** | SQL exact-match for error constants + sibling co-retrieval from the same source file + MMR vector search — error code answers always include the defining constant. |
+| **Production / demo separation** | Demo, test, mock, and sample packages are ranked below production code so the LLM cites real implementations, not sample apps. |
 | **Incremental updates** | `run_update.py` re-crawls only changed/new content across docs, community, GitHub, Confluence, and Jira |
 | **LangSmith observability** | Full trace visibility — zero code changes, just env vars |
 
 ## Tech Stack
 
 | Component | Choice |
-|---|---|
+| --- | --- |
 | Framework | LangChain 1.x (LCEL) |
-| LLM | Groq — `llama-3.3-70b-versatile` |
+| LLM | **BYOK** — Groq / Anthropic / OpenAI (user-supplied key via Settings page); Groq server key for ingestion pipeline only |
+| MCP | `mcp` + FastMCP — SSE transport for Claude Desktop integration (port 8002) |
 | Embeddings | HuggingFace `intfloat/multilingual-e5-base` (768-dim, 100+ languages) |
 | Vector DB | pgvector (PostgreSQL extension — ACID, SQL filtering, pg_dump backups) |
 | Crawlers | `requests` + `BeautifulSoup` + Discourse API + GitHub REST API + Atlassian REST API |
 | Observability | LangSmith (optional, free tier) |
-| UI | Streamlit |
+| UI | Streamlit multi-page (chat + settings) |
 | Package manager | `uv` |
 | Python | 3.13 |
 
 ## Project Structure
 
-```
+```text
 MosipNexus/
 ├── config/
 │   └── settings.py              # All constants, env bindings, and tuneable params
 ├── crawler/
-│   ├── docs_crawler.py          # Sitemap crawler → mosip_docs.json
+│   ├── docs_crawler.py          # Sitemap crawler → mosip_docs.json (tables converted to prose)
 │   ├── community_crawler.py     # Discourse API crawler → mosip_community.json
 │   ├── github_crawler.py        # GitHub Issues API (auto-discovers 86 repos) → mosip_github.json
 │   ├── code_crawler.py          # GitHub Tree API for source files → mosip_code.json
-│   ├── confluence_crawler.py    # Atlassian REST API → mosip_confluence.json
+│   ├── confluence_crawler.py    # Atlassian REST API → mosip_confluence.json (tables converted to prose)
 │   ├── jira_crawler.py          # Atlassian Jira API → mosip_jira.json (optional)
+│   ├── utils.py                 # Shared crawler utilities (table_to_prose)
 │   └── state.py                 # Crawl state persistence for incremental updates
 ├── ingestion/
 │   └── store.py                 # Chunk, embed, upsert into pgvector collections
 ├── retrieval/
-│   ├── retriever.py             # MMR search across all collections + confidence scoring
+│   ├── retriever.py             # Hybrid retrieval: MMR + SQL exact-match + sibling co-retrieval + production/demo separation
 │   └── dedup.py                 # Duplicate question detection
 ├── chain/
-│   ├── query_engine.py          # Main LCEL RAG chain (condense → retrieve → answer)
+│   ├── query_engine.py          # LCEL RAG chain — BYOK multi-provider, query classification, specialised system prompts
 │   └── summarizer.py            # Long thread summarisation
 ├── memory/
 │   └── session.py               # Session-level chat history
 ├── notifications/
 │   └── email_notifier.py        # Optional email alerts for unanswerable questions
+├── mcp_server/
+│   └── server.py                # FastMCP server — exposes search_mosip + list_knowledge_sources tools (port 8002)
 ├── app/
-│   └── app.py                   # Streamlit chat UI
+│   ├── app.py                   # Streamlit chat UI
+│   └── pages/
+│       └── settings.py          # Settings page — LLM provider, API key (BYOK), model selector
 ├── run_update.py                 # Incremental update runner
 ├── data/                         # Crawled JSON files (committed — skips re-crawl for new cloners)
 └── .env                          # Local secrets (gitignored)
@@ -125,7 +136,9 @@ Create `MosipNexus/.env` with the following variables:
 # Required — PostgreSQL connection string
 PG_CONNECTION="postgresql+psycopg://mosip:your_password@localhost:5432/mosipnexus"
 
-# Required
+# Optional — used only by the ingestion pipeline (thread summariser).
+# NOT used for user queries — users bring their own key via the Settings page (BYOK)
+# or connect via Claude Desktop + MCP (no API key needed at all).
 GROQ_API_KEY="your_groq_api_key"          # free at console.groq.com
 
 # Optional — avoids HuggingFace rate limits on model downloads
@@ -201,6 +214,41 @@ uv run streamlit run MosipNexus/app/app.py
 
 Open [http://localhost:8501](http://localhost:8501).
 
+## Claude Desktop / MCP Integration
+
+MOSIP Nexus exposes a Model Context Protocol (MCP) server that Claude Desktop can connect to. When connected, Claude calls `search_mosip` for retrieval and uses your own Claude subscription for the LLM — zero API cost for the app owner.
+
+### Connecting Claude Desktop
+
+**Step 1** — Open Claude Desktop → Settings → Developer → Edit Config
+
+**Step 2** — Add to `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "mosip-nexus": {
+      "url": "http://localhost:8002/sse"
+    }
+  }
+}
+```
+
+*(For production: replace `localhost:8002` with your deployed URL, e.g. `https://mosip-nexus.env.mosip.net/mcp/sse`)*
+
+**Step 3** — Restart Claude Desktop. Verify `mosip-nexus` appears under Developer → MCP Servers.
+
+**Step 4** — Ask Claude any MOSIP question. It automatically calls `search_mosip` and answers using your Claude subscription.
+
+### Available MCP Tools
+
+| Tool | Description |
+| --- | --- |
+| `search_mosip(query)` | Search all five knowledge sources simultaneously. Returns top chunks with source URLs. |
+| `list_knowledge_sources()` | Show live record counts for each indexed source. |
+
+---
+
 ## Usage
 
 - Type any MOSIP question in the chat box
@@ -212,7 +260,7 @@ Open [http://localhost:8501](http://localhost:8501).
 
 ## How It Works
 
-```
+```text
 User question
       │
       ▼

--- a/MosipNexus/api/main.py
+++ b/MosipNexus/api/main.py
@@ -105,17 +105,34 @@ class ChatRequest(BaseModel):
     question: str = Field(..., min_length=1, description="Question to ask about MOSIP.")
     session_id: str | None = Field(None, description="Pass previous session_id to continue conversation.")
     language: str = Field("English", description="Response language e.g. English, Tamil, Hindi.")
+    llm_provider: str = Field("groq", description="LLM provider: 'groq' (default) | 'anthropic' | 'openai'.")
+    llm_api_key: str | None = Field(None, description="User's own API key (BYOK). Never logged or stored.")
+    llm_model: str | None = Field(None, description="Optional model override e.g. 'claude-haiku-4-5-20251001'.")
 
 
 @app.post("/chat", response_model=ChatResponse, tags=["Chat"],
           summary="Ask a MOSIP question",
           description="Main RAG endpoint. Returns answer + sources + confidence. Pass `session_id` from the response back to maintain conversation context.")
 def chat(req: ChatRequest) -> ChatResponse:
+    if not req.llm_api_key:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "llm_api_key is required. Provide your own Groq, Anthropic, or OpenAI API key. "
+                "No server-side LLM key is available."
+            ),
+        )
+
     session_id = req.session_id or str(uuid.uuid4())
     memory = _get_session(session_id)
 
     try:
-        result = ask(req.question, memory.messages, req.language)
+        result = ask(
+            req.question, memory.messages, req.language,
+            llm_provider=req.llm_provider,
+            llm_api_key=req.llm_api_key,
+            llm_model=req.llm_model,
+        )
     except Exception as e:
         logger.exception("Error in /chat for session %s", session_id)
         raise HTTPException(status_code=500, detail="An internal error occurred. Please try again.")
@@ -463,6 +480,9 @@ class BatchRequest(BaseModel):
     questions: list[str] = Field(..., min_length=1, max_length=10, description="List of questions (max 10).")
     session_id: str | None = Field(None, description="Shared session — questions are answered sequentially, each aware of previous.")
     language: str = Field("English", description="Response language for all questions.")
+    llm_provider: str = Field("groq", description="LLM provider: 'groq' | 'anthropic' | 'openai'.")
+    llm_api_key: str | None = Field(None, description="User's own API key (BYOK). Never logged or stored.")
+    llm_model: str | None = Field(None, description="Optional model override.")
 
 
 class BatchResponse(BaseModel):
@@ -475,6 +495,15 @@ class BatchResponse(BaseModel):
           summary="Ask multiple questions at once",
           description="Process up to 10 questions sequentially in a single request. Each question is aware of the previous answers (shared session context).")
 def batch(req: BatchRequest) -> BatchResponse:
+    if not req.llm_api_key:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "llm_api_key is required. Provide your own Groq, Anthropic, or OpenAI API key. "
+                "No server-side LLM key is available."
+            ),
+        )
+
     session_id = req.session_id or str(uuid.uuid4())
     memory = _get_session(session_id)
 
@@ -485,7 +514,12 @@ def batch(req: BatchRequest) -> BatchResponse:
 
     for i, question in enumerate(req.questions):
         try:
-            result = ask(question, temp_messages, req.language)
+            result = ask(
+                question, temp_messages, req.language,
+                llm_provider=req.llm_provider,
+                llm_api_key=req.llm_api_key,
+                llm_model=req.llm_model,
+            )
         except Exception as e:
             logger.exception("Error in /batch on question index %d", i)
             raise HTTPException(status_code=500, detail="An internal error occurred. Please try again.")

--- a/MosipNexus/app/app.py
+++ b/MosipNexus/app/app.py
@@ -344,7 +344,12 @@ if query:
 # Collapse default Streamlit sidebar top padding
 st.markdown("""
 <style>
-[data-testid="stSidebarContent"] { padding-top: 1rem !important; }
+/* Hide Streamlit's auto-generated multi-page nav links ("app", "settings") */
+[data-testid="stSidebarNav"] { display: none !important; }
+/* Remove all top space above logo */
+[data-testid="stSidebarContent"] { padding-top: 0 !important; }
+section[data-testid="stSidebar"] > div:first-child { padding-top: 0 !important; }
+[data-testid="stSidebarContent"] > div:first-child { margin-top: -0.75rem !important; }
 /* Section spacing */
 [data-testid="stSidebarContent"] hr { margin: 1.4rem 0 !important; border-color: #e5e7eb !important; }
 [data-testid="stSidebarContent"] .stMarkdown p { margin-bottom: 0.3rem !important; }
@@ -392,10 +397,26 @@ section[data-testid="stSidebar"] { scrollbar-width: none; }
     left: 19rem;
 }
 </style>
-<div class="mosip-footer">
-  Powered by LangChain &nbsp;·&nbsp; Groq Llama 3.3 &nbsp;·&nbsp; pgvector &nbsp;·&nbsp; HuggingFace
-</div>
 """, unsafe_allow_html=True)
+
+_provider_key = st.session_state.get("llm_provider", "groq")
+_has_key = bool(st.session_state.get("llm_api_key"))
+_active_provider_label = {
+    "anthropic": "Claude (Anthropic)",
+    "openai": "OpenAI",
+    "groq": "Groq",
+}.get(_provider_key, "Groq") if _has_key else None
+
+_footer_parts = ["LangChain", "pgvector", "HuggingFace"]
+if _active_provider_label:
+    _footer_parts.insert(1, _active_provider_label)
+
+st.markdown(
+    f'<div class="mosip-footer">Powered by &nbsp;'
+    f'{"&nbsp; · &nbsp;".join(_footer_parts)}'
+    f'</div>',
+    unsafe_allow_html=True,
+)
 
 _logo_data: str | None = base64.b64encode(_LOGO.read_bytes()).decode() if _LOGO.exists() else None
 
@@ -465,6 +486,9 @@ with st.sidebar:
     st.markdown("**Sources searched**")
     st.markdown(_SIDEBAR_SOURCES_HTML, unsafe_allow_html=True)
 
+    st.divider()
+    st.page_link("pages/settings.py", label="⚙️ Settings")
+
 # ── Main title ─────────────────────────────────────────────────────────────────
 if _logo_data:
     st.markdown(
@@ -482,6 +506,25 @@ st.markdown(
     '</p>',
     unsafe_allow_html=True,
 )
+
+# ── Persistent session state defaults (must match settings.py) ────────────────
+if "llm_api_key" not in st.session_state:
+    st.session_state["llm_api_key"] = ""
+if "llm_provider" not in st.session_state:
+    st.session_state["llm_provider"] = "groq"
+
+# ── No-LLM banner ─────────────────────────────────────────────────────────────
+if not st.session_state.get("llm_api_key"):
+    st.markdown(
+        '<div style="background:#fffbeb; border:1px solid #fcd34d; border-radius:8px; '
+        'padding:0.7rem 1rem; font-size:0.875rem; color:#92400e; margin-bottom:0.5rem;">'
+        '⚠️ &nbsp;<strong>No LLM configured.</strong> &nbsp;Go to '
+        '<a href="/settings" target="_self" style="color:#6366f1; font-weight:600; '
+        'text-decoration:none;">Settings</a> '
+        'to add your own Claude, OpenAI, or Groq API key — or use Claude Desktop with the MCP integration.'
+        '</div>',
+        unsafe_allow_html=True,
+    )
 
 # ── Scroll-to-bottom button + auto-scroll ─────────────────────────────────────
 import streamlit.components.v1 as _components
@@ -612,7 +655,12 @@ if query:
     # ── Generate answer ────────────────────────────────────────────────────────
     with st.chat_message("assistant"):
         with st.spinner("Searching docs and community forum..."):
-            result = ask(query, memory.messages, memory.language)
+            result = ask(
+                query, memory.messages, memory.language,
+                llm_provider=st.session_state.get("llm_provider", "groq"),
+                llm_api_key=st.session_state.get("llm_api_key"),
+                llm_model=st.session_state.get("llm_model"),
+            )
 
         answer       = result["answer"]
         sources      = result["sources"]

--- a/MosipNexus/app/pages/settings.py
+++ b/MosipNexus/app/pages/settings.py
@@ -1,0 +1,383 @@
+"""
+MOSIP Nexus — Settings Page
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+import streamlit as st
+
+st.set_page_config(
+    page_title="Settings — MOSIP Nexus",
+    page_icon="⚙️",
+    layout="centered",
+)
+
+# ── Styles ──────────────────────────────────────────────────────────────────────
+st.markdown("""
+<style>
+/* Hide Streamlit's auto-generated multi-page nav links */
+[data-testid="stSidebarNav"] { display: none !important; }
+[data-testid="stSidebarContent"] { padding-top: 1rem !important; }
+[data-testid="stSidebarContent"] hr { margin: 1rem 0 !important; border-color: #e5e7eb !important; }
+
+/* Section label above containers */
+.nx-section-label {
+    font-size: 0.72rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.09em;
+    color: #9ca3af;
+    margin-bottom: 0.6rem;
+}
+.nx-section-title {
+    font-size: 1rem;
+    font-weight: 600;
+    color: #111827;
+    margin-bottom: 0.25rem;
+}
+.nx-section-desc {
+    font-size: 0.83rem;
+    color: #6b7280;
+    margin-bottom: 0.8rem;
+    line-height: 1.5;
+}
+
+/* Status badge */
+.nx-status-ok {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    background: #f0fdf4;
+    border: 1px solid #86efac;
+    border-radius: 20px;
+    padding: 0.35rem 0.9rem;
+    font-size: 0.82rem;
+    font-weight: 600;
+    color: #15803d;
+}
+.nx-status-warn {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    background: #fffbeb;
+    border: 1px solid #fcd34d;
+    border-radius: 20px;
+    padding: 0.35rem 0.9rem;
+    font-size: 0.82rem;
+    font-weight: 600;
+    color: #b45309;
+}
+
+/* Provider radio cards */
+div[data-testid="stRadio"] > div {
+    gap: 0.55rem !important;
+    flex-wrap: wrap;
+}
+div[data-testid="stRadio"] label {
+    background: #f9fafb !important;
+    border: 1.5px solid #e5e7eb !important;
+    border-radius: 9px !important;
+    padding: 0.55rem 1.1rem !important;
+    font-size: 0.875rem !important;
+    font-weight: 500 !important;
+    color: #374151 !important;
+    cursor: pointer;
+    transition: all 0.15s ease;
+    min-width: 110px;
+    justify-content: center;
+}
+div[data-testid="stRadio"] label:hover {
+    border-color: #6366f1 !important;
+    background: #f5f3ff !important;
+    color: #4338ca !important;
+}
+
+/* Privacy pill */
+.nx-privacy {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    background: #f0f9ff;
+    border: 1px solid #bae6fd;
+    border-radius: 6px;
+    padding: 0.35rem 0.7rem;
+    font-size: 0.77rem;
+    color: #0369a1;
+    margin-top: 0.4rem;
+}
+
+/* MCP card inside container */
+.nx-mcp-card {
+    background: linear-gradient(135deg, #faf5ff 0%, #ede9fe 100%);
+    border: 1px solid #c4b5fd;
+    border-radius: 10px;
+    padding: 1rem 1.2rem 0.9rem;
+    margin-bottom: 0.75rem;
+}
+.nx-mcp-card-title {
+    font-size: 0.9rem;
+    font-weight: 600;
+    color: #4c1d95;
+    margin-bottom: 0.25rem;
+}
+.nx-mcp-card-desc {
+    font-size: 0.81rem;
+    color: #6d28d9;
+    line-height: 1.45;
+}
+.nx-badge {
+    display: inline-block;
+    background: #7c3aed;
+    color: white;
+    font-size: 0.68rem;
+    font-weight: 700;
+    letter-spacing: 0.05em;
+    padding: 0.15rem 0.5rem;
+    border-radius: 4px;
+    margin-left: 0.4rem;
+    vertical-align: middle;
+}
+
+/* Key link */
+.nx-key-link {
+    font-size: 0.78rem;
+    color: #6366f1;
+}
+</style>
+""", unsafe_allow_html=True)
+
+# ── Sidebar ──────────────────────────────────────────────────────────────────────
+with st.sidebar:
+    st.page_link("app.py", label="← Back to Chat", icon="💬")
+    st.divider()
+    st.caption("MOSIP Nexus")
+
+# ── Page header ──────────────────────────────────────────────────────────────────
+st.markdown("## ⚙️ Settings")
+st.markdown(
+    '<p style="color:#6b7280; font-size:0.875rem; margin-top:-0.5rem; margin-bottom:1.4rem;">'
+    'Configure your LLM provider. Changes apply immediately to your session only.'
+    '</p>',
+    unsafe_allow_html=True,
+)
+
+# ── Persistent session state defaults (survive page navigation) ───────────────
+if "llm_api_key" not in st.session_state:
+    st.session_state["llm_api_key"] = ""
+if "llm_provider" not in st.session_state:
+    st.session_state["llm_provider"] = "groq"
+
+# ── Status badge placeholder — filled after widgets run ───────────────────────
+_status_placeholder = st.empty()
+st.markdown("<br>", unsafe_allow_html=True)
+
+# ── LLM Configuration ────────────────────────────────────────────────────────────
+st.markdown('<div class="nx-section-label">LLM Configuration</div>', unsafe_allow_html=True)
+
+with st.container(border=True):
+    st.markdown(
+        '<div class="nx-section-title">🤖 Choose your AI provider</div>'
+        '<div class="nx-section-desc">Select a provider and enter your own API key. '
+        'Your key stays in your browser session and is never stored on the server.</div>',
+        unsafe_allow_html=True,
+    )
+
+    _PROVIDER_MAP = {
+        "Groq": "groq",
+        "Claude — Anthropic": "anthropic",
+        "OpenAI": "openai",
+    }
+    _PROVIDER_REVERSE = {v: k for k, v in _PROVIDER_MAP.items()}
+
+    current_provider_key = st.session_state.get("llm_provider", "groq")
+    current_label = _PROVIDER_REVERSE.get(current_provider_key, "Groq")
+
+    selected_label = st.radio(
+        "Provider",
+        options=list(_PROVIDER_MAP.keys()),
+        index=list(_PROVIDER_MAP.keys()).index(current_label),
+        horizontal=True,
+        label_visibility="collapsed",
+    )
+
+    selected_provider = _PROVIDER_MAP[selected_label]
+    st.session_state["llm_provider"] = selected_provider
+
+    st.markdown("<br style='line-height:0.5rem'>", unsafe_allow_html=True)
+
+    # Provider-specific config
+    if selected_provider == "groq":
+        key_placeholder, key_link = "gsk_...", "https://console.groq.com"
+        key_link_label = "Get a free key at console.groq.com →"
+        model_options = [
+            "llama-3.3-70b-versatile (recommended)",
+            "llama-3.1-8b-instant (faster)",
+            "mixtral-8x7b-32768",
+        ]
+        model_values = ["llama-3.3-70b-versatile", "llama-3.1-8b-instant", "mixtral-8x7b-32768"]
+    elif selected_provider == "anthropic":
+        key_placeholder, key_link = "sk-ant-...", "https://console.anthropic.com"
+        key_link_label = "Get your key at console.anthropic.com →"
+        model_options = [
+            "claude-haiku-4-5-20251001 (fastest, recommended)",
+            "claude-sonnet-4-6 (balanced)",
+            "claude-opus-4-8 (most capable)",
+        ]
+        model_values = ["claude-haiku-4-5-20251001", "claude-sonnet-4-6", "claude-opus-4-8"]
+    else:
+        key_placeholder, key_link = "sk-...", "https://platform.openai.com/api-keys"
+        key_link_label = "Get your key at platform.openai.com →"
+        model_options = [
+            "gpt-4o-mini (fastest, recommended)",
+            "gpt-4o (balanced)",
+            "gpt-4-turbo (most capable)",
+        ]
+        model_values = ["gpt-4o-mini", "gpt-4o", "gpt-4-turbo"]
+
+    col_key, col_model = st.columns([3, 2])
+
+    with col_key:
+        st.markdown(
+            f'<a class="nx-key-link" href="{key_link}" target="_blank">{key_link_label}</a>',
+            unsafe_allow_html=True,
+        )
+        # Seed the widget key from the persistent key when returning to this page
+        if "_api_key_widget" not in st.session_state:
+            st.session_state["_api_key_widget"] = st.session_state["llm_api_key"]
+
+        def _sync_api_key():
+            # on_change fires before script reruns — persistent key is always current
+            st.session_state["llm_api_key"] = st.session_state.get("_api_key_widget", "")
+
+        st.text_input(
+            "API Key",
+            type="password",
+            placeholder=key_placeholder,
+            key="_api_key_widget",
+            on_change=_sync_api_key,
+            label_visibility="collapsed",
+        )
+        api_key = st.session_state.get("llm_api_key", "")
+
+    with col_model:
+        st.caption("Model")
+        current_model = st.session_state.get("llm_model", model_values[0])
+        model_index = model_values.index(current_model) if current_model in model_values else 0
+        selected_model_label = st.selectbox(
+            "Model",
+            options=model_options,
+            index=model_index,
+            label_visibility="collapsed",
+        )
+        st.session_state["llm_model"] = model_values[model_options.index(selected_model_label)]
+
+    if api_key:
+        st.success("API key saved for this session. You can now start chatting.", icon="✅")
+    else:
+        st.caption("Enter your API key above to activate this provider.")
+
+    # ── Fill status badge now that we have the real values ────────────────────
+    _provider_display = {
+        "groq": "Groq",
+        "anthropic": "Claude (Anthropic)",
+        "openai": "OpenAI",
+    }.get(selected_provider, "Groq")
+
+    if api_key:
+        _status_placeholder.markdown(
+            f'<span class="nx-status-ok">✓ &nbsp;Active — {_provider_display}</span>',
+            unsafe_allow_html=True,
+        )
+    else:
+        _status_placeholder.markdown(
+            '<span class="nx-status-warn">⚠ &nbsp;No LLM configured</span>',
+            unsafe_allow_html=True,
+        )
+
+    st.markdown(
+        '<div class="nx-privacy">🔒 &nbsp;Key is session-only — never logged, stored, or shared.</div>',
+        unsafe_allow_html=True,
+    )
+
+# ── Claude Desktop / MCP ─────────────────────────────────────────────────────────
+st.markdown("<br style='line-height:0.2rem'>", unsafe_allow_html=True)
+st.markdown('<div class="nx-section-label">Alternative Access</div>', unsafe_allow_html=True)
+
+with st.container(border=True):
+    st.markdown(
+        '<div class="nx-mcp-card">'
+        '<div class="nx-mcp-card-title">🖥️ Claude Desktop (MCP Integration)'
+        '<span class="nx-badge">No API key needed</span></div>'
+        '<div class="nx-mcp-card-desc">'
+        'Connect Claude Desktop directly to MOSIP Nexus. Claude uses your own subscription '
+        'for the AI — MosipNexus only handles knowledge retrieval.'
+        '</div></div>',
+        unsafe_allow_html=True,
+    )
+
+    with st.expander("Setup guide — Claude Desktop"):
+        st.markdown("""
+**Step 1** — Open Claude Desktop → Settings → Developer → Edit Config
+
+**Step 2** — Add to `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "mosip-nexus": {
+      "command": "uv",
+      "args": [
+        "--directory", "D:\\\\path\\\\to\\\\MosipNexus",
+        "run", "python", "mcp_server/server.py"
+      ],
+      "env": {
+        "PYTHONPATH": "D:\\\\path\\\\to\\\\MosipNexus",
+        "PG_CONNECTION": "postgresql+psycopg://mosip:mosip@localhost:5432/mosipnexus"
+      }
+    }
+  }
+}
+```
+*(Replace the path and PG_CONNECTION with your actual values.)*
+
+**Step 3** — Restart Claude Desktop → verify "mosip-nexus" appears under Developer → MCP Servers.
+
+**Step 4** — Ask Claude any MOSIP question. It calls `search_mosip` automatically and answers using your Claude subscription.
+""")
+
+# ── Preferences ──────────────────────────────────────────────────────────────────
+st.markdown("<br style='line-height:0.2rem'>", unsafe_allow_html=True)
+st.markdown('<div class="nx-section-label">Preferences</div>', unsafe_allow_html=True)
+
+with st.container(border=True):
+    st.markdown(
+        '<div style="font-size:0.875rem; font-weight:500; color:#374151; margin-bottom:0.1rem;">'
+        'Max chat history turns</div>'
+        '<div style="font-size:0.78rem; color:#9ca3af; margin-bottom:0.5rem;">'
+        'Older turns are dropped to keep token usage low.</div>',
+        unsafe_allow_html=True,
+    )
+    max_turns = st.slider(
+        "Max chat history turns",
+        min_value=5, max_value=30,
+        value=st.session_state.get("max_history_turns", 10),
+        step=5,
+        label_visibility="collapsed",
+    )
+    st.session_state["max_history_turns"] = max_turns
+
+# ── About ─────────────────────────────────────────────────────────────────────────
+st.markdown(
+    '<div style="text-align:center; padding: 1.4rem 0 0.5rem; font-size:0.78rem; color:#9ca3af; line-height:1.8;">'
+    '<strong style="color:#6b7280;">MOSIP Nexus</strong> v1.0 &nbsp;·&nbsp; '
+    'LangChain &nbsp;·&nbsp; pgvector &nbsp;·&nbsp; HuggingFace<br>'
+    '449 docs &nbsp;·&nbsp; 849 community threads &nbsp;·&nbsp; 797 GitHub issues &nbsp;·&nbsp; '
+    '1,738 Confluence pages &nbsp;·&nbsp; 6,566 source files'
+    '</div>',
+    unsafe_allow_html=True,
+)

--- a/MosipNexus/chain/query_engine.py
+++ b/MosipNexus/chain/query_engine.py
@@ -5,7 +5,7 @@ Pipeline for each user question:
   1. Pure greeting → direct friendly reply (no RAG).
   2. Message starting with greeting → RAG answer prefixed with a brief greeting.
   3. Condense follow-up questions using chat history (LCEL condenser chain).
-  4. Retrieve top-K chunks from both ChromaDB collections via MMR.
+  4. Retrieve top-K chunks from all pgvector collections via MMR.
   5. Score confidence from the best chunk's cosine distance.
   6. Generate answer grounded strictly in context (Groq Llama 3.3).
   7. If retrieved context is irrelevant → emit [NO_DOC_SOURCE] marker.
@@ -18,6 +18,7 @@ and LANGCHAIN_API_KEY are set in the environment — no code changes needed.
 
 from __future__ import annotations
 
+import re
 import sys
 from pathlib import Path
 from typing import Any
@@ -25,14 +26,70 @@ from typing import Any
 from langchain_core.messages import HumanMessage, SystemMessage
 from langchain_core.output_parsers import StrOutputParser
 from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
+from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_groq import ChatGroq
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 from config.settings import GROQ_API_KEY, GROQ_MODEL
 from retrieval.retriever import retrieve, _ERROR_CODE_RE, _CODE_QUERY_RE
 
+# Detects "works locally but fails in hosted/staging/synergy/production" debugging questions.
+# These require a fundamentally different answer shape: focus on environmental differences,
+# not generic troubleshooting steps.
+_ENV_DEBUG_RE = re.compile(
+    r"work(?:s|ed|ing)?\s+(?:fine\s+)?(?:locally|local|on\s+local)|"
+    r"local(?:ly)?\s+(?:it\s+)?work(?:s|ed)|"
+    r"(?:synergy|hosted|production|staging|remote)\s+(?:env(?:ironment)?|setup)",
+    re.IGNORECASE,
+)
+
 _llm: ChatGroq | None = None
 _condenser = None
+
+
+def build_llm(
+    provider: str = "groq",
+    api_key: str | None = None,
+    model: str | None = None,
+) -> BaseChatModel:
+    """Factory — returns a chat model for the given provider and key.
+
+    api_key is required for all providers. For internal backend use (ingestion,
+    summarizer) the server's GROQ_API_KEY is used as fallback; user-facing
+    ask() enforces BYOK before reaching here.
+    """
+    if provider == "anthropic":
+        from langchain_anthropic import ChatAnthropic
+        return ChatAnthropic(
+            model=model or "claude-haiku-4-5-20251001",
+            api_key=api_key,  # type: ignore[arg-type]
+        )
+    if provider == "openai":
+        from langchain_openai import ChatOpenAI
+        return ChatOpenAI(
+            model=model or "gpt-4o-mini",
+            api_key=api_key,  # type: ignore[arg-type]
+        )
+    # groq — api_key required for user queries; backend falls back to server key
+    return ChatGroq(
+        model=model or GROQ_MODEL,
+        api_key=api_key or GROQ_API_KEY,
+    )
+
+
+_NO_LLM_RESPONSE: dict = {
+    "answer": (
+        "⚙️ **No LLM configured.**\n\n"
+        "To use the web interface, go to **⚙️ Settings** (sidebar) and enter your own "
+        "API key for Claude (Anthropic), OpenAI, or Groq.\n\n"
+        "Alternatively, use **Claude Desktop** with the MCP integration — "
+        "no API key needed, queries run on your own Claude subscription."
+    ),
+    "sources": [],
+    "source_type": "none",
+    "confidence": "n/a",
+    "similar_questions": [],
+}
 
 _GREETINGS = {
     "hi", "hello", "hey", "hola", "bonjour", "namaste", "vanakkam",
@@ -75,22 +132,23 @@ language.\
 _NO_SOURCE_MARKER = "[NO_DOC_SOURCE]"
 
 
+_CONDENSE_PROMPT = ChatPromptTemplate.from_messages([
+    ("system",
+     "Given the conversation history and the latest question, rewrite the question "
+     "as a standalone search query that captures all necessary context. "
+     "Return ONLY the rewritten question, nothing else."),
+    MessagesPlaceholder("chat_history"),
+    ("human", "{input}"),
+])
+
+
 def _build() -> None:
     global _llm, _condenser
-    _llm = ChatGroq(model=GROQ_MODEL, api_key=GROQ_API_KEY)
-
-    condense_prompt = ChatPromptTemplate.from_messages([
-        ("system",
-         "Given the conversation history and the latest question, rewrite the question "
-         "as a standalone search query that captures all necessary context. "
-         "Return ONLY the rewritten question, nothing else."),
-        MessagesPlaceholder("chat_history"),
-        ("human", "{input}"),
-    ])
-    _condenser = condense_prompt | _llm | StrOutputParser()
+    _llm = build_llm()
+    _condenser = _CONDENSE_PROMPT | _llm | StrOutputParser()
 
 
-def _get_llm() -> ChatGroq:
+def _get_llm() -> BaseChatModel:
     if _llm is None:
         _build()
     assert _llm is not None
@@ -125,6 +183,7 @@ def _web_fallback_or_none(
     question: str,
     language: str,
     fallback_answer: str | None = None,
+    llm: BaseChatModel | None = None,
 ) -> dict[str, Any]:
     """Try a web search when the knowledge base has no usable context; otherwise
     return a plain "not available" response instead of letting the LLM guess."""
@@ -134,7 +193,7 @@ def _web_fallback_or_none(
             f"[{h.get('title', '')}]({h['href']})\n{h['body']}"
             for h in web_hits
         )
-        llm = _get_llm()
+        assert llm is not None, "llm must be provided to _web_fallback_or_none"
         web_response = llm.invoke([
             SystemMessage(content=(
                 f"You are a helpful assistant. The MOSIP knowledge base did not have "
@@ -182,18 +241,64 @@ def _build_system_prompt(
     has_greeting: bool,
     is_error_query: bool = False,
     is_code_query: bool = False,
+    is_env_debug: bool = False,
 ) -> str:
+    """Build the system prompt for one RAG turn.
+
+    is_env_debug and is_error_query can both be true simultaneously
+    (e.g. an error code that only appears in a hosted environment).
+    In that case env_debug takes format priority and error rules are appended.
+    """
     greeting_rule = (
         "Start with one warm sentence acknowledging the greeting, then answer directly.\n"
         if has_greeting else ""
     )
-    if is_error_query:
+    if is_env_debug:
+        answer_format = (
+            "This is an environment-comparison debugging question — the user says the same thing "
+            "works locally but fails in a hosted/remote environment (Synergy, production, staging, etc.). "
+            "Structure your answer as:\n"
+            "  1. Confirm the key insight: the biometric data / request payload itself is NOT the problem "
+            "(it works locally). The failure is in the hosted environment's configuration or version.\n"
+            "  2. IMPORTANT — do NOT treat HTTP status codes (401, 500, 403, etc.) as MOSIP error codes "
+            "(like IDA-MLC-009 or KER-ATH-401). In this context, 401 means the hosted service returned "
+            "HTTP 401 Unauthorized, and 500 means the hosted service threw an internal error. "
+            "Treat them as HTTP-level responses from that specific service (BQAT, SBI, biosdk-service, etc.).\n"
+            "  3. List what differs between local and hosted environments — focus on: "
+            "version/image tag mismatch, credential or API key requirements in the hosted env, "
+            "network policies or IP allowlists, config drift in values.yaml or application.properties.\n"
+            "  4. Give specific next steps to narrow down which env difference is causing it. "
+            "For 401 from a remote service: check whether the hosted service requires auth headers "
+            "the local Docker image does not. "
+            "For 500 from a remote service: check the hosted service pod logs for the actual stack trace.\n"
+            "  5. If the retrieved context includes community threads about this exact issue, "
+            "cite them by name. If those threads have no accepted answer, say so explicitly — "
+            "do not invent a resolution that isn't in the context.\n\n"
+        )
+        if is_error_query:
+            answer_format += (
+                "Additionally, this query references a specific MOSIP error code — "
+                "apply the error code rules: quote the exact constant, flag %s/%d as "
+                "runtime placeholders, and compare sibling error codes if present.\n\n"
+            )
+    elif is_error_query:
         answer_format = (
             "For this error code question, structure your answer as:\n"
-            "  1. What the error means (one clear sentence)\n"
-            "  2. Most likely root cause(s) — list in order of likelihood\n"
-            "  3. Step-by-step resolution\n"
-            "  4. How to verify the fix worked\n\n"
+            "  1. Exact error definition — quote the constant from source code if available. "
+            "CRITICAL: if the message contains %s, %d, or any Java format specifier, state "
+            "explicitly that this is a runtime placeholder substituted with the actual offending "
+            "value in the API response. NEVER replace %s with a specific example value and present "
+            "it as the definition. Tell the user to read their actual error response to see what "
+            "field name was substituted.\n"
+            "  2. How this differs from sibling error codes in the same file — e.g. 'missing' vs "
+            "'present but invalid' — if sibling constants appear in the retrieved context.\n"
+            "  3. Most likely root causes specific to this error, ranked by likelihood. "
+            "Do NOT list generic causes that apply to any error — only causes grounded in the "
+            "retrieved context or in how this specific constant is used in the codebase.\n"
+            "  4. Step-by-step resolution — first step MUST be: check your actual error response "
+            "for the substituted field name (%s value), since that tells you exactly which "
+            "parameter is failing.\n"
+            "  5. How to verify the fix worked.\n\n"
         )
     elif is_code_query:
         answer_format = (
@@ -203,7 +308,13 @@ def _build_system_prompt(
             "  - Mention key methods if they are in the context.\n"
             "  - If multiple classes share the responsibility, list them in order of importance.\n"
             "  - If the exact class is not in the context, name the closest class you CAN identify "
-            "and clearly state what aspect of the question it covers.\n\n"
+            "and clearly state what aspect of the question it covers.\n"
+            "  - CRITICAL: if the only matching class in the retrieved context is from a demo, "
+            "test, sample, mock, or simulator package (e.g. io.mosip.*.demo.*, SampleSDK, "
+            "DemoService), you MUST state explicitly: 'This class is from the demo/test "
+            "application, NOT the production implementation.' Then describe what the production "
+            "class likely does based on the pattern, but make clear the exact production class "
+            "name is not in the available context.\n\n"
         )
     else:
         answer_format = (
@@ -257,6 +368,11 @@ def _build_system_prompt(
         f"- Prioritise content marked [ACCEPTED ANSWER] — these are verified solutions.\n"
         f"- GitHub Issues in the context show real error reports with real solutions — use them.\n"
         f"- When source code file names appear in context, cite them by name and explain their role.\n"
+        f"- When community threads appear in the context about the same issue as the query, "
+        f"ALWAYS cite them explicitly by their exact title from the context. "
+        f"If the thread contains a resolution or ACCEPTED ANSWER, summarise it. "
+        f"If the thread has no accepted answer, say so explicitly — "
+        f"this signals an unresolved known issue the user should follow or escalate.\n"
         f"- ONLY output {_NO_SOURCE_MARKER} at the very start if the question is completely "
         f"unrelated to MOSIP (e.g. weather, sports, general coding unrelated to MOSIP). "
         f"For any MOSIP question — even with limited context — give your best answer.\n"
@@ -269,6 +385,9 @@ def ask(
     question: str,
     chat_history: list,
     language: str = "English",
+    llm_provider: str = "groq",
+    llm_api_key: str | None = None,
+    llm_model: str | None = None,
 ) -> dict[str, Any]:
     """Run the full RAG pipeline for one user turn.
 
@@ -276,6 +395,9 @@ def ask(
         question:     Raw user message.
         chat_history: LangChain HumanMessage / AIMessage objects from prior turns.
         language:     Human-readable language name for the LLM response language.
+        llm_provider: "groq" | "anthropic" | "openai" — defaults to server Groq key.
+        llm_api_key:  User-supplied API key (BYOK); None uses server default.
+        llm_model:    Optional model override (e.g. "claude-haiku-4-5-20251001").
 
     Returns:
         answer      (str):       generated response text.
@@ -284,7 +406,12 @@ def ask(
         confidence  (str):       "high" | "medium" | "low" | "n/a".
         similar_questions (list[str]): titles of related community threads (may be empty).
     """
-    llm = _get_llm()
+    # Require the user to supply their own API key — no server fallback.
+    if not llm_api_key:
+        return _NO_LLM_RESPONSE
+
+    llm = build_llm(llm_provider, llm_api_key, llm_model)
+    condenser = _CONDENSE_PROMPT | llm | StrOutputParser()
 
     # ── Pure greeting ──────────────────────────────────────────────────────────
     if _is_greeting(question):
@@ -314,13 +441,9 @@ def ask(
         }
 
     # ── Condense follow-up questions ───────────────────────────────────────────
-    if _condenser is None:
-        _build()
-    assert _condenser is not None
-
     try:
         standalone = (
-            _condenser.invoke({"input": question, "chat_history": chat_history})
+            condenser.invoke({"input": question, "chat_history": chat_history})
             if chat_history
             else question
         )
@@ -336,13 +459,24 @@ def ask(
     # No chunks retrieved at all — don't let the LLM guess from pretrained
     # knowledge, go straight to the same web-fallback path as [NO_DOC_SOURCE].
     if not docs:
-        return _web_fallback_or_none(question, language)
+        return _web_fallback_or_none(question, language, llm=llm)
 
     # ── Build QA chain ─────────────────────────────────────────────────────────
     has_greeting = _starts_with_greeting(question)
+    # Check both original question and condensed form — condensation can strip env signals
+    # (e.g. "Synergy environment", "works locally") from a long community-post paste
+    is_env_debug   = bool(_ENV_DEBUG_RE.search(question)) or bool(_ENV_DEBUG_RE.search(standalone))
     is_error_query = bool(_ERROR_CODE_RE.search(standalone))
-    is_code_query = not is_error_query and bool(_CODE_QUERY_RE.search(standalone))
-    system_prompt = _build_system_prompt(language, has_greeting, is_error_query, is_code_query)
+    # env_debug + error_query can both be true (e.g. "IDA-MLC-009 in Synergy, works locally")
+    # env_debug takes format priority but error_query rules still apply inside that format.
+    # code_query is mutually exclusive with both since code analysis ≠ debugging/error context.
+    is_code_query  = not is_error_query and not is_env_debug and bool(_CODE_QUERY_RE.search(standalone))
+    system_prompt = _build_system_prompt(
+        language, has_greeting,
+        is_error_query=is_error_query,
+        is_code_query=is_code_query,
+        is_env_debug=is_env_debug,
+    )
 
     qa_prompt = ChatPromptTemplate.from_messages([
         ("system", system_prompt),
@@ -380,7 +514,7 @@ def ask(
     # ── [NO_DOC_SOURCE] → try DuckDuckGo web search fallback ─────────────────
     if _NO_SOURCE_MARKER in answer:
         fallback_answer = answer.replace(_NO_SOURCE_MARKER, "").lstrip()
-        return _web_fallback_or_none(question, language, fallback_answer)
+        return _web_fallback_or_none(question, language, fallback_answer, llm=llm)
 
     # ── Classify sources ───────────────────────────────────────────────────────
     source_types = {d.metadata.get("source_type", "") for d in docs}

--- a/MosipNexus/chain/summarizer.py
+++ b/MosipNexus/chain/summarizer.py
@@ -12,21 +12,21 @@ import os
 import sys
 from pathlib import Path
 
+from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.messages import HumanMessage, SystemMessage
-from langchain_groq import ChatGroq
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
-from config.settings import GROQ_API_KEY, GROQ_MODEL
+from chain.query_engine import build_llm
 
-_llm: ChatGroq | None = None
+_llm: BaseChatModel | None = None
 
 MIN_ANSWERS_TO_SUMMARIZE = 4   # threads with fewer answers are used as-is
 
 
-def _get_llm() -> ChatGroq:
+def _get_llm() -> BaseChatModel:
     global _llm
     if _llm is None:
-        _llm = ChatGroq(model=GROQ_MODEL, api_key=GROQ_API_KEY)
+        _llm = build_llm()
     return _llm
 
 

--- a/MosipNexus/config/settings.py
+++ b/MosipNexus/config/settings.py
@@ -56,6 +56,7 @@ PIPELINE_VERSION = _hashlib.md5(
 # ── Retrieval ──────────────────────────────────────────────────────────────────
 RETRIEVAL_K       = 8    # final chunks returned per collection
 RETRIEVAL_FETCH_K = 30   # MMR candidate pool
+MAX_CONTEXT_DOCS  = 40   # hard cap on total docs passed to LLM (prevents context overflow)
 
 # Cosine similarity (1 = identical).  Above this → treat as duplicate question.
 DEDUP_THRESHOLD = 0.88

--- a/MosipNexus/crawler/confluence_crawler.py
+++ b/MosipNexus/crawler/confluence_crawler.py
@@ -19,6 +19,7 @@ import time
 from pathlib import Path
 
 import requests
+from bs4 import BeautifulSoup
 from markdownify import markdownify
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
@@ -27,6 +28,7 @@ from config.settings import (
     CONFLUENCE_TOKEN, CONFLUENCE_URL, CONFLUENCE_USER,
     CRAWL_DELAY_SECS,
 )
+from crawler.utils import table_to_prose
 
 
 def _is_configured() -> bool:
@@ -75,7 +77,17 @@ def page_to_dict(page: dict) -> dict | None:
     labels    = [lb["name"] for lb in page.get("metadata", {}).get("labels", {}).get("results", [])]
     version   = page.get("version", {}).get("number", 0)
 
-    content = markdownify(html, heading_style="ATX", strip=["script", "style"]).strip()
+    # Convert tables to prose before markdownify so Confluence spec/config
+    # tables embed correctly (header+value pairs instead of raw pipe-cells).
+    soup = BeautifulSoup(html, "html.parser")
+    for table in soup.find_all("table"):
+        prose = table_to_prose(table)
+        if prose:
+            replacement = soup.new_tag("p")
+            replacement.string = prose
+            table.replace_with(replacement)
+
+    content = markdownify(str(soup), heading_style="ATX", strip=["script", "style"]).strip()
     if len(content) < 100:
         return None
 

--- a/MosipNexus/crawler/docs_crawler.py
+++ b/MosipNexus/crawler/docs_crawler.py
@@ -22,6 +22,7 @@ from config.settings import (
     DOCS_FILE, DOCS_SITEMAP_URL, DOCS_BASE_URL,
     HTTP_HEADERS, CRAWL_DELAY_SECS,
 )
+from crawler.utils import table_to_prose
 
 _SM_NS = {"sm": "http://www.sitemaps.org/schemas/sitemap/0.9"}
 
@@ -73,6 +74,17 @@ def fetch_page_as_markdown(url: str) -> str:
         or soup.body
         or soup
     )
+
+    # Convert tables to prose before markdownify so specs/configs embed correctly.
+    # markdownify produces pipe-tables whose cells lack context without headers;
+    # prose like "vCPU: 12, RAM: 32 GB, Disk: 128 GB" retrieves far better.
+    for table in content.find_all("table"):
+        prose = table_to_prose(table)
+        if prose:
+            replacement = soup.new_tag("p")
+            replacement.string = prose
+            table.replace_with(replacement)
+
     return markdownify(
         str(content),
         heading_style="ATX",

--- a/MosipNexus/crawler/utils.py
+++ b/MosipNexus/crawler/utils.py
@@ -1,0 +1,40 @@
+"""Shared crawler utilities."""
+
+from __future__ import annotations
+
+
+def table_to_prose(table_tag) -> str:
+    """Convert an HTML <table> to labelled prose sentences for better embedding.
+
+    Pipe-table cells like '| 32 GB |' carry no semantic meaning without their
+    header. Converting each row to 'vCPU: 12, RAM: 32 GB, Disk: 128 GB.' lets
+    the embedding model match hardware/config queries correctly.
+
+    Handles:
+    - Standard <th> header + <td> data rows
+    - All-<td> tables (no explicit header)
+    - colspan/rowspan: cells are flattened via get_text — no special handling
+    - Nested tables: get_text() recurses into them automatically
+    - Empty rows: skipped
+    """
+    rows = table_tag.find_all("tr")
+    if not rows:
+        return ""
+
+    has_th = bool(rows[0].find_all("th"))
+    header_cells = rows[0].find_all("th") if has_th else rows[0].find_all("td")
+    headers = [c.get_text(" ", strip=True) for c in header_cells]
+    data_rows = rows[1:] if has_th else rows
+
+    sentences: list[str] = []
+    for row in data_rows:
+        cells = [td.get_text(" ", strip=True) for td in row.find_all(["th", "td"])]
+        if not any(cells):
+            continue
+        if headers and len(headers) == len(cells):
+            parts = [f"{h}: {c}" for h, c in zip(headers, cells) if h and c]
+        else:
+            parts = [c for c in cells if c]
+        if parts:
+            sentences.append(", ".join(parts) + ".")
+    return "\n".join(sentences)

--- a/MosipNexus/docker-compose.yml
+++ b/MosipNexus/docker-compose.yml
@@ -43,6 +43,25 @@ services:
       postgres:
         condition: service_healthy
 
+  # ── MCP Server (Claude Desktop integration) ────────────────────────────────
+  nexus-mcp:
+    build: .
+    command:
+      - uv
+      - run
+      - python
+      - mcp_server/server.py
+    env_file: .env
+    environment:
+      PG_CONNECTION: "postgresql+psycopg://mosip:mosip@postgres:5432/mosipnexus"
+      PYTHONPATH: /app/MosipNexus
+      MCP_PORT: "8002"
+    ports:
+      - "8002:8002"
+    depends_on:
+      postgres:
+        condition: service_healthy
+
   # ── Streamlit UI ────────────────────────────────────────────────────────────
   nexus-ui:
     build: .

--- a/MosipNexus/docs/MOSIP_Nexus_Rancher_Deployment_Guide.md
+++ b/MosipNexus/docs/MOSIP_Nexus_Rancher_Deployment_Guide.md
@@ -6,7 +6,7 @@
 
 ## 1. Overview
 
-This document covers the infrastructure requirements and step-by-step deployment of MOSIP Nexus AI on a Rancher Kubernetes cluster. MOSIP Nexus AI consists of three runtime components — a FastAPI backend, a Streamlit chat UI, and a PostgreSQL database with the pgvector extension — plus a nightly CronJob that keeps the knowledge base up to date.
+This document covers the infrastructure requirements and step-by-step deployment of MOSIP Nexus AI on a Rancher Kubernetes cluster. MOSIP Nexus AI consists of four runtime components — a FastAPI backend, a Streamlit chat UI, a FastMCP server (for Claude Desktop / MCP integration), and a PostgreSQL database with the pgvector extension — plus a nightly CronJob that keeps the knowledge base up to date.
 
 All Kubernetes manifests are included in the repository under `MosipNexus/k8s/`.
 
@@ -17,7 +17,7 @@ All Kubernetes manifests are included in the repository under `MosipNexus/k8s/`.
 ### 2.1 Compute — Node Specifications
 
 | Tier | CPU | RAM | Suitable For |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | **Minimum (single node)** | 8 cores | 16 GB | Internal pilot, development |
 | **Recommended (production)** | 8 cores × 2 nodes | 32 GB × 2 nodes | High availability, rolling restarts |
 
@@ -26,18 +26,19 @@ All Kubernetes manifests are included in the repository under `MosipNexus/k8s/`.
 Each pod running the HuggingFace embedding model (`multilingual-e5-base`) loads approximately 1.1 GB of model weights into RAM (measured from the cached model files, not estimated). During the nightly knowledge update, the embedding process is CPU-intensive. The table below shows the resource footprint at steady state and during the nightly update.
 
 | Component | CPU (steady) | RAM (steady) | Notes |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | nexus-postgres (pgvector) | 0.25 cores | 512 MB | Stores all vector embeddings |
 | nexus-api (FastAPI) | 0.5 cores | ~2.5 GB | HF model loaded in memory |
 | nexus-ui (Streamlit) | 0.25 cores | ~2.5 GB | HF model loaded in memory |
-| **Total — steady state** | **~1 core** | **~5.5 GB** | |
+| nexus-mcp (FastMCP / Claude Desktop) | 0.25 cores | ~2.5 GB | HF model loaded in memory; port 8002 |
+| **Total — steady state** | **~1.25 cores** | **~8 GB** | |
 | nexus-updater (nightly CronJob) | 1–4 cores | 4–8 GB | Runs ~15 min nightly, not always active |
 | **Total — during nightly update** | **~5 cores** | **~13 GB** | |
 
 ### 2.2 Storage Requirements
 
 | Volume | Size | Purpose |
-|---|---|---|
+| --- | --- | --- |
 | postgres-data PVC | 20 GB | pgvector embeddings (~70,000 chunks across all knowledge sources) |
 | nexus-data PVC | 10 GB | Crawled JSON files and crawl state (used by nightly CronJob) |
 | Node disk (per node) | 50 GB minimum | OS, Kubernetes, and Docker image (~3.5 GB image) |
@@ -47,7 +48,7 @@ Each pod running the HuggingFace embedding model (`multilingual-e5-base`) loads 
 Measured from the actual built image (`docker image inspect`), not estimated:
 
 | Layer | Size (raw layer diff) |
-|---|---|
+| --- | --- |
 | Debian + Python 3.13 base | ~220 MB |
 | `uv sync` — LangChain, PyTorch CPU, transformers, psycopg, etc. | ~5.7 GB |
 | Application source code (`COPY . .`) | ~1 MB |
@@ -63,7 +64,7 @@ Measured from the actual built image (`docker image inspect`), not estimated:
 ### 2.4 Software Prerequisites
 
 | Requirement | Version | Notes |
-|---|---|---|
+| --- | --- | --- |
 | Rancher | 2.7 or later | Or any Kubernetes 1.28+ cluster |
 | nginx Ingress Controller | Any current | Included with Rancher by default |
 | Storage class | Any ReadWriteOnce | `local-path` works for single-node; use NFS for multi-node |
@@ -74,7 +75,7 @@ Measured from the actual built image (`docker image inspect`), not estimated:
 ### 2.5 Network Requirements
 
 | Item | Requirement |
-|---|---|
+| --- | --- |
 | Exposed ports | 80 / 443 via nginx Ingress (no direct NodePort needed) |
 | Internal cluster networking | Standard pod-to-pod networking (no special config) |
 | DNS entries | `nexus.mosip.io` → Streamlit UI, `nexus-api.mosip.io` → FastAPI |
@@ -84,7 +85,7 @@ Measured from the actual built image (`docker image inspect`), not estimated:
 ### 2.6 API Keys and Credentials Required
 
 | Credential | Where to Get | Required? |
-|---|---|---|
+| --- | --- | --- |
 | `GROQ_API_KEY` | console.groq.com (free) | **Required** |
 | `PG_CONNECTION` | Set from PostgreSQL deployment | **Required** |
 | `GITHUB_TOKEN` | github.com → Settings → Developer settings | Optional (raises rate limit from 60 to 5,000 req/hr) |
@@ -444,7 +445,7 @@ kubectl exec -n mosip-nexus deploy/nexus-api -- `
 ## 6. Troubleshooting
 
 | Symptom | Likely Cause | Fix |
-|---|---|---|
+| --- | --- | --- |
 | Pod stuck in `Pending` | PVC not bound | Check storage class: `kubectl describe pvc -n mosip-nexus` |
 | Pod stuck in `CrashLoopBackOff` | Missing secret or wrong DB password | `kubectl logs <pod> -n mosip-nexus` to see the error |
 | `/health` returns `degraded` | pgvector unreachable or empty | Check postgres pod is running; verify PG_CONNECTION in secret |
@@ -459,7 +460,7 @@ kubectl exec -n mosip-nexus deploy/nexus-api -- `
 ## 7. Kubernetes Manifest Summary
 
 | File | What It Creates |
-|---|---|
+| --- | --- |
 | `k8s/00-namespace.yaml` | `mosip-nexus` namespace |
 | `k8s/01-postgres.yaml` | pgvector StatefulSet, PVC (20 GB), Service, init ConfigMap |
 | `k8s/02-secret.yaml` | All secrets — fill before applying |

--- a/MosipNexus/mcp_server/server.py
+++ b/MosipNexus/mcp_server/server.py
@@ -1,0 +1,171 @@
+"""
+MOSIP Nexus MCP Server
+
+Exposes the MOSIP knowledge base as MCP tools so Claude Desktop (or any
+MCP-compatible client) can search it using the user's own Claude subscription.
+The LLM runs on the client side — this server only performs vector retrieval.
+
+Run standalone:
+    uv run python mcp/server.py
+
+Users add this to their Claude Desktop config (~/.claude/claude_desktop_config.json):
+
+    For local Docker deployment:
+    {
+      "mcpServers": {
+        "mosip-nexus": {
+          "url": "http://localhost:8002/sse"
+        }
+      }
+    }
+
+    For production (after deployment):
+    {
+      "mcpServers": {
+        "mosip-nexus": {
+          "url": "https://mosip-nexus.env.mosip.net/mcp/sse"
+        }
+      }
+    }
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import threading
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from mcp.server.fastmcp import FastMCP
+
+# Pre-load the retriever in the background so the first tool call is instant.
+# The embedding model takes ~60s to load — doing it here avoids Claude Desktop
+# timing out on the first search_mosip call.
+_retrieve_fn = None
+
+def _warmup():
+    global _retrieve_fn
+    from retrieval.retriever import retrieve
+    retrieve("mosip warmup")   # triggers model + pgvector init
+    _retrieve_fn = retrieve
+
+threading.Thread(target=_warmup, daemon=True).start()
+
+MCP_PORT = int(os.getenv("MCP_PORT", "8002"))
+
+mcp = FastMCP(
+    "mosip-nexus",
+    instructions=(
+        "You have access to the MOSIP (Modular Open Source Identity Platform) knowledge base. "
+        "Use search_mosip to find relevant documentation, community answers, GitHub issues, "
+        "Confluence pages, and source code before answering MOSIP questions.\n\n"
+        "CITATION AND SOURCE TRANSPARENCY RULES:\n"
+        "- Always include the source URL inline when citing a result. Use the format: "
+        "[Source: <url>] placed immediately after the fact you are citing.\n"
+        "- For source code results, name the exact file (e.g. IdAuthenticationErrorConstants.java) "
+        "and the constant or method you are referencing.\n"
+        "- CRITICAL — never silently blend Nexus results with web search or training data. "
+        "If the specific fact (e.g. a hardware spec table, a version number, a config value) "
+        "is NOT present in search_mosip results, say so explicitly before supplementing: "
+        "'The Nexus knowledge base does not contain this specific detail — the following is from "
+        "[web search / my training data]:'. This keeps the user informed about data provenance "
+        "and prevents them from treating community forum posts as official verified specs.\n"
+        "- If search_mosip returns general context but not the specific numbers or values the "
+        "user asked for, state: 'Nexus confirmed the topic exists but did not return the exact "
+        "figures — I found them via [source].' Do not present web-sourced numbers as if they "
+        "came from Nexus.\n\n"
+        "ERROR CODE RULES (applies when answering about codes like IDA-MLC-009):\n"
+        "- Read the exact error message string from the source code constant. "
+        "If it contains %s, %d, or any Java format specifier, state clearly that this is a "
+        "RUNTIME PLACEHOLDER substituted with the actual offending field/value at runtime. "
+        "NEVER replace %s with a specific example value and present it as the error definition.\n"
+        "- Tell the user to read their actual error response — the substituted %s value in the "
+        "JSON response body is the specific field that is missing or invalid in their case.\n"
+        "- If the retrieved context includes sibling constants from the same file "
+        "(e.g. IDA-MLC-008 and IDA-MLC-009 side by side), compare them explicitly so the user "
+        "understands the distinction (e.g. 'missing parameter' vs 'present but invalid')."
+    ),
+    port=MCP_PORT,
+    host="0.0.0.0",
+)
+
+
+@mcp.tool()
+def search_mosip(query: str) -> str:
+    """Search the MOSIP knowledge base.
+
+    Returns relevant content from:
+    - MOSIP official documentation (docs.mosip.io)
+    - Community forum Q&A threads (community.mosip.io)
+    - GitHub issues from 25 active MOSIP repositories
+    - Confluence pages (engineering, QA, product management, support desk)
+    - MOSIP source code (Java, YAML, SQL, XML, properties files)
+
+    Args:
+        query: The question or topic to search for (any language supported).
+
+    Returns:
+        Formatted context from the top matching chunks, with source metadata.
+    """
+    if _retrieve_fn is None:
+        return (
+            "The MOSIP Nexus knowledge base is still initializing "
+            "(loading the embedding model — takes ~60 seconds on first start). "
+            "Please try again in a moment."
+        )
+    docs, confidence = _retrieve_fn(query)
+
+    if not docs:
+        return "No relevant content found in the MOSIP knowledge base for this query."
+
+    parts: list[str] = [f"Confidence: {confidence}\n"]
+    for doc in docs:
+        meta = doc.metadata
+        source_type = meta.get("source_type", "unknown")
+        source_url = meta.get("source", "")
+        title = meta.get("title", "")
+
+        header = f"[{source_type.upper()}]"
+        if title:
+            header += f" {title}"
+        if source_url:
+            header += f"\n📎 {source_url}"
+
+        parts.append(f"{header}\n\n{doc.page_content}")
+
+    return "\n\n---\n\n".join(parts)
+
+
+@mcp.tool()
+def list_knowledge_sources() -> str:
+    """List all knowledge sources indexed in MOSIP Nexus with live record counts."""
+    try:
+        from retrieval.retriever import get_collection_counts
+        counts = get_collection_counts()
+    except Exception:
+        counts = {}
+
+    def _count(key: str) -> str:
+        return f"{counts[key]:,} chunks" if key in counts else "not indexed"
+
+    return (
+        "MOSIP Nexus Knowledge Base — Available Sources:\n\n"
+        f"1. **MOSIP Documentation** ({_count('docs')}) — docs.mosip.io/1.2.0\n"
+        "   Covers: architecture, modules, deployment guides, API references, configuration\n\n"
+        f"2. **Community Forum** ({_count('community')}) — community.mosip.io\n"
+        "   Covers: real-world Q&A, accepted solutions, deployment issues, integration questions\n\n"
+        f"3. **GitHub Issues** ({_count('github')}) — 25 active MOSIP repositories\n"
+        "   Covers: bug reports, feature discussions, error resolutions, workarounds\n\n"
+        f"4. **Confluence** ({_count('confluence')}) — QT, ENGG, PMS, MSD spaces\n"
+        "   Covers: internal engineering docs, QA processes, product management, support desk\n\n"
+        f"5. **Source Code** ({_count('code')}) — 71 MOSIP repositories\n"
+        "   Covers: Java classes, YAML configs, SQL schemas, error constants, properties files\n\n"
+        "Use search_mosip(query) to search across all sources simultaneously."
+    )
+
+
+if __name__ == "__main__":
+    transport = os.getenv("MCP_TRANSPORT", "stdio")
+    mcp.run(transport=transport)

--- a/MosipNexus/pyproject.toml
+++ b/MosipNexus/pyproject.toml
@@ -24,6 +24,9 @@ dependencies = [
     "psycopg[binary]>=3.1.0",
     "pydantic>=2.13.3",
     "sqlalchemy>=2.0.0",
+    "mcp>=1.0",
+    "langchain-anthropic>=0.3",
+    "langchain-openai>=0.3",
 ]
 
 [tool.pyright]

--- a/MosipNexus/retrieval/retriever.py
+++ b/MosipNexus/retrieval/retriever.py
@@ -23,10 +23,18 @@ from config.settings import (
     COMMUNITY_COLLECTION, CONFLUENCE_COLLECTION, CONFIDENCE_HIGH,
     CONFIDENCE_MEDIUM, DOCS_COLLECTION, EMBED_MODEL,
     GITHUB_COLLECTION, GITHUB_RETRIEVAL_K, JIRA_COLLECTION,
-    RETRIEVAL_FETCH_K, RETRIEVAL_K,
+    MAX_CONTEXT_DOCS, RETRIEVAL_FETCH_K, RETRIEVAL_K,
 )
 
 _ERROR_CODE_RE = re.compile(r'\b[A-Z]{2,}-[A-Z]{2,}-\d{3,}\b')
+_FORMAT_SPECIFIER_RE = re.compile(r'%[sd]')
+# Packages that are demo/test/sample apps — ranked lower than production code.
+# A result from io.mosip.authentication.demo is NOT the production class.
+_DEMO_PACKAGE_RE = re.compile(
+    r'\b(?:\.demo\.|\.test\.|\.sample\.|\.mock\.|\.simulator\.|SampleSDK|DemoService)',
+    re.IGNORECASE,
+)
+_SIBLING_FILE_RE = re.compile(r'error(?:code|codes|constants)?\.java$', re.IGNORECASE)
 _CODE_QUERY_RE = re.compile(
     r"\b(class|method|interface|package|service|impl|handler|processor|"
     r"java|spring|bean|annotation|controller|repository|util|helper|"
@@ -118,6 +126,104 @@ def get_collection_counts() -> dict[str, int]:
     return counts
 
 
+def _exact_code_search(error_code: str, collection_name: str, limit: int = 5) -> list[Document]:
+    """SQL ILIKE search for chunks that literally contain the error code string.
+
+    Bypasses vector similarity so the defining constant is always surfaced even
+    when its embedding drifts from the query phrasing.
+    """
+    try:
+        with _get_pg_engine().connect() as conn:
+            rows = conn.execute(
+                _sql_text(
+                    "SELECT e.document, e.cmetadata "
+                    "FROM langchain_pg_embedding e "
+                    "JOIN langchain_pg_collection c ON e.collection_id = c.uuid "
+                    "WHERE c.name = :coll "
+                    "AND e.document ILIKE :pattern "
+                    "LIMIT :limit"
+                ),
+                {"coll": collection_name, "pattern": f"%{error_code}%", "limit": limit},
+            ).fetchall()
+        return [Document(page_content=row[0], metadata=row[1] or {}) for row in rows]
+    except Exception:
+        return []
+
+
+def _sibling_chunks(title: str, collection_name: str, limit: int = 8) -> list[Document]:
+    """Retrieve additional chunks from the same source file by title match.
+
+    When we land on an error-constants file, pulling sibling chunks provides the
+    surrounding constant definitions so the LLM can compare related error codes.
+    """
+    try:
+        with _get_pg_engine().connect() as conn:
+            rows = conn.execute(
+                _sql_text(
+                    "SELECT e.document, e.cmetadata "
+                    "FROM langchain_pg_embedding e "
+                    "JOIN langchain_pg_collection c ON e.collection_id = c.uuid "
+                    "WHERE c.name = :coll "
+                    "AND e.cmetadata->>'title' = :title "
+                    "LIMIT :limit"
+                ),
+                {"coll": collection_name, "title": title, "limit": limit},
+            ).fetchall()
+        return [Document(page_content=row[0], metadata=row[1] or {}) for row in rows]
+    except Exception:
+        return []
+
+
+def _split_production_vs_demo(docs: list[Document]) -> tuple[list[Document], list[Document]]:
+    """Partition code chunks into production code vs. demo/test/sample code.
+
+    Demo packages (*.demo.*, SampleSDK, etc.) rank lower than production code
+    for production questions — prevents the LLM from citing a demo-app class
+    as if it were the real IDA/kernel/regproc implementation.
+    """
+    production: list[Document] = []
+    demo: list[Document] = []
+    for doc in docs:
+        if _DEMO_PACKAGE_RE.search(doc.page_content) or _DEMO_PACKAGE_RE.search(
+            doc.metadata.get("source", "") + " " + doc.metadata.get("title", "")
+        ):
+            demo.append(doc)
+        else:
+            production.append(doc)
+    return production, demo
+
+
+def _annotate_format_specifiers(docs: list[Document]) -> list[Document]:
+    """Inline-annotate code chunks that contain Java format specifiers (%s, %d).
+
+    When an error-constant definition like `"Invalid Input parameter - %s"` appears
+    in retrieved context, LLMs often substitute a specific example value seen elsewhere
+    in training data (e.g. "id") instead of correctly identifying it as a placeholder.
+    This annotation is placed right next to the format string so any LLM reads the
+    warning in context without relying solely on system prompt instructions.
+    """
+    annotated: list[Document] = []
+    for doc in docs:
+        if (
+            doc.metadata.get("source_type") == "code"
+            and _FORMAT_SPECIFIER_RE.search(doc.page_content)
+            and _ERROR_CODE_RE.search(doc.page_content)
+        ):
+            annotation = (
+                "\n⚠️  NOTE FOR LLM: This chunk contains Java format specifiers (%s / %d). "
+                "These are RUNTIME PLACEHOLDERS — the actual field name or value is substituted "
+                "at runtime and appears in the real API error response. "
+                "DO NOT replace %s with any specific value (such as 'id') in your answer. "
+                "Tell the user to read their actual error response for the substituted value."
+            )
+            doc = Document(
+                page_content=doc.page_content + annotation,
+                metadata=doc.metadata,
+            )
+        annotated.append(doc)
+    return annotated
+
+
 def _get_stores() -> tuple[PGVector, PGVector]:
     if _docs_store is None:
         _build()
@@ -165,15 +271,44 @@ def retrieve(query: str, k: int = RETRIEVAL_K) -> tuple[list[Document], str]:
         github_results = github_retriever.invoke(query)
 
     code_results: list[Document] = []
+    exact_results: list[Document] = []
+    sibling_results: list[Document] = []
     if _code_store is not None:
         # 3× boost for error-code queries and explicit code/class questions
-        _is_targeted_code = _ERROR_CODE_RE.search(query) or _CODE_QUERY_RE.search(query)
+        _error_match = _ERROR_CODE_RE.search(query)
+        _is_targeted_code = _error_match or _CODE_QUERY_RE.search(query)
         code_k = CODE_RETRIEVAL_K * 3 if _is_targeted_code else CODE_RETRIEVAL_K
         code_retriever = _code_store.as_retriever(
             search_type="mmr",
             search_kwargs={"k": code_k, "fetch_k": RETRIEVAL_FETCH_K},
         )
         code_results = code_retriever.invoke(query)
+
+        if _error_match:
+            error_code = _error_match.group()
+            # Fix 3: SQL keyword search so the defining constant is always retrieved
+            exact_results = _exact_code_search(error_code, CODE_COLLECTION)
+            # Fix 4: pull sibling constants from every error-constants file we landed on.
+            # Matches files like IdAuthenticationErrorConstants.java, AuthAdapterErrorCode.java,
+            # KernelErrorCodes.java, PacketManagerErrorCodes.java, etc.
+            seen_titles: set[str] = set()
+            for doc in exact_results + code_results:
+                title = doc.metadata.get("title", "")
+                if title and _SIBLING_FILE_RE.search(title) and title not in seen_titles:
+                    seen_titles.add(title)
+                    sibling_results.extend(_sibling_chunks(title, CODE_COLLECTION))
+
+    # Split code results: production code ranks above demo/test/sample code
+    _prod_code, _demo_code = _split_production_vs_demo(exact_results + sibling_results + code_results)
+
+    # Deduplicate by content while preserving priority order:
+    # exact/sibling production code → doc/community/github → demo/test code (last resort)
+    _seen: set[str] = set()
+    _deduped: list[Document] = []
+    for doc in _prod_code + doc_results + community_results + github_results + _demo_code:
+        if doc.page_content not in _seen:
+            _seen.add(doc.page_content)
+            _deduped.append(doc)
 
     # Confidence from the best relevance score across all searched collections.
     # similarity_search_with_relevance_scores returns [0, 1] regardless of the
@@ -203,4 +338,4 @@ def retrieve(query: str, k: int = RETRIEVAL_K) -> tuple[list[Document], str]:
     else:
         confidence = "low"
 
-    return doc_results + community_results + github_results + code_results, confidence
+    return _annotate_format_specifiers(_deduped[:MAX_CONTEXT_DOCS]), confidence

--- a/MosipNexus/uv.lock
+++ b/MosipNexus/uv.lock
@@ -147,6 +147,25 @@ wheels = [
 ]
 
 [[package]]
+name = "anthropic"
+version = "0.116.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "docstring-parser" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/a2/d31f14e28d49bae983a3634e38dfb4b31c50110b5e403596c5c6a20b23f8/anthropic-0.116.0.tar.gz", hash = "sha256:5fc248fbb9fe03ef686f8a774f81586bca31a043260aab88b387ea3660f4a396", size = 949149, upload-time = "2026-07-02T19:08:10.534Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/dd/2a1e81cf1b163acc340afc4ec74ed1d86f5eed1a809fabdeed3e0997b346/anthropic-0.116.0-py3-none-any.whl", hash = "sha256:6c0a7698e8d652455da3499978279bb2588c7264d0a35be3666009a4258c8256", size = 956896, upload-time = "2026-07-02T19:08:08.756Z" },
+]
+
+[[package]]
 name = "anyio"
 version = "4.14.0"
 source = { registry = "https://pypi.org/simple" }
@@ -240,6 +259,79 @@ wheels = [
 ]
 
 [[package]]
+name = "cffi"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/57/5f/ff100cae70ebe9d8df1c01a00e510e45d9adb5c1fdda84791b199141de97/cffi-2.1.0.tar.gz", hash = "sha256:efc1cdd798b1aaf39b4610bba7aad28c9bea9b910f25c784ccf9ec1fa719d1f9", size = 531036, upload-time = "2026-07-06T21:34:30.382Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/88/a996879e2eeccb815f6e3a5967b12a308257412acec882039d386bd2aa7b/cffi-2.1.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:10537b1df4967ca26d21e5072d7d54188354483b91dc75058968d3f0cf13fbda", size = 194331, upload-time = "2026-07-06T21:33:03.697Z" },
+    { url = "https://files.pythonhosted.org/packages/58/85/7ae00d5c8dd6266f4e944c3db630f3c5c9a98b61d469c714d848b1d8138a/cffi-2.1.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:a95b05f9baf29b91171b3a8bd2020b028835243e7b0ff6bb23e2a3c228518b1b", size = 196966, upload-time = "2026-07-06T21:33:05.353Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/e9/45c3a76ad8d43ad9261f4c95436da61128d3ca545d72b9612c0ab5be0b1c/cffi-2.1.0-cp313-cp313-macosx_10_15_x86_64.whl", hash = "sha256:15faec4adfff450819f3aee0e2e02c812de6edb88203aa58807955db2003472a", size = 184795, upload-time = "2026-07-06T21:33:06.699Z" },
+    { url = "https://files.pythonhosted.org/packages/84/4c/82f132cb4418ee6d953d982b19191e87e2a6372c8a4ce36e50b69d6ade4a/cffi-2.1.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:716ff8ec22f20b4d988b12884086bcef0fc99737043e503f7a3935a6be99b1ea", size = 184746, upload-time = "2026-07-06T21:33:08.071Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1c/4ed5a0e5bdca6cbc275556de3328dd1b76fd0c11cc13c88fe66d1d8715f2/cffi-2.1.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:63960549e4f8dc41e31accb97b975abaecfc44c03e396c093a6436763c2ea7db", size = 214747, upload-time = "2026-07-06T21:33:09.671Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/a6/e879bb68cc23a2bc9ba8f4b7d8019f0c2694bad2ab6c4a3701d429439f58/cffi-2.1.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ff067a8d8d880e7809e4ac88eb009bb848870115317b306666502ccad30b147f", size = 222392, upload-time = "2026-07-06T21:33:10.896Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f6/01890cfd63c08f8eb96a8319b0443690197d240a8bd6346048cf7bde9190/cffi-2.1.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:3b926723c13eba9f81d2ef3820d63aeceec3b2d4639906047bf675cb8a7a500d", size = 210285, upload-time = "2026-07-06T21:33:12.251Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/cf/2b684132056f438567b61e19d690dd31cd0921ace051e0a458be6074369e/cffi-2.1.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:47ff3a8bfd8cb9da1af7524b965127095055654c177fcfc7578debcb015eecd0", size = 208801, upload-time = "2026-07-06T21:33:13.617Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/08/f2e7d62c460faae0926f2d6e423694aa409ced3bc1fe2927a0a6e5f05416/cffi-2.1.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:799416bae98336e400981ff6e532d67d5c709cfb30afb79865a1315f94b0e224", size = 221808, upload-time = "2026-07-06T21:33:15.466Z" },
+    { url = "https://files.pythonhosted.org/packages/38/37/04f54b8e63a02f3d908332c9effbf8c366167c6f733ed8a3d4f79b7e2a1e/cffi-2.1.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:961be50688f7fba2fa65f63712d3b9b341a22311f5253460ce933f52f0de1c8c", size = 225241, upload-time = "2026-07-06T21:33:16.869Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/d6/c72eecca433cd3e681c65ed313ab4835d9d4a379704d0f628a6a05f51c2e/cffi-2.1.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:bf5c6cf48238b0eb4c086978c492ad1cbc22373fc5b2d7353b3a598ce6db887a", size = 223588, upload-time = "2026-07-06T21:33:18.239Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/4b/e706f67279140f92939da3475ad610df18bfd52d50f14953a8e5fede71d5/cffi-2.1.0-cp313-cp313-win32.whl", hash = "sha256:db3eb7d46527159a878ec3460e9d40615bc25ba337d477db681aea6e4f05c5d2", size = 175248, upload-time = "2026-07-06T21:33:19.799Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/47/59eb7975cb0e4ef0afa764ea945b29a5bb4537a9f771cb7d6c8a5dd74c95/cffi-2.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:8e74a6135550c4748af665b1b1118b6aab33b1fc6a16f9aff630af107c3b4512", size = 185717, upload-time = "2026-07-06T21:33:21.47Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/af/34fee85c48f8d94efc8597bc09470c9dd274c145f1c12e0fbc6ab6d38d74/cffi-2.1.0-cp313-cp313-win_arm64.whl", hash = "sha256:2282cd5e38aa8accd03e99d1256af8411c84cdbee6a89d841b563fdbd1f3e50f", size = 180114, upload-time = "2026-07-06T21:33:22.515Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/f0/81478e482afa03f6d18dc8f2afb5edc45b3080853b634b5ed91961be0998/cffi-2.1.0-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:d2117334c3af3bdcb9a88522b844a2bdb5efdc4f71c6c822df55486ae1c3347a", size = 194142, upload-time = "2026-07-06T21:33:23.657Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/95/8de304305cd9204974b0ca051b86d307cafca13aa575a0ef1b44d92c0d8c/cffi-2.1.0-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:702c436735fbe99d59ada02a1f65cfc0d31c0ee8b7290912f8fbc5cd1e4b16c3", size = 196819, upload-time = "2026-07-06T21:33:25.007Z" },
+    { url = "https://files.pythonhosted.org/packages/20/71/7c8372d30e42415602ed9f268f7cfd66f1b855fed881ecd168bcb45dbc0b/cffi-2.1.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:1ff3456eab0d889592d1936d6125bbfbc7ae4d3354a700f8bd80450a66445d4d", size = 184965, upload-time = "2026-07-06T21:33:26.605Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/5c/584e626835f0375c928176c04137c96927165cb8733cdb3150ec04e5ee5e/cffi-2.1.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c4165821e131d6d4ca444347c2b694e2311bcfa3fe5a861cc72968f28867beac", size = 184952, upload-time = "2026-07-06T21:33:27.823Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/d2/065fcae1c73979fac8e054462478d0ff8a29c40cdc2ed7ea5676a061df53/cffi-2.1.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:276f20fffd7b396e12516ba8edf9509210ac248cbbc5acbc39cd512f9f59ebe6", size = 222353, upload-time = "2026-07-06T21:33:29.178Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/a5/e8bbb1ce5b3ac2f53ad6a10bde44318a5a8d99d4f4a000d44a6e39aeb3e4/cffi-2.1.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:7d5980a3433d4b71a5e120f9dd551403d7824e31e2e67124fe2769c404c06913", size = 210051, upload-time = "2026-07-06T21:33:30.534Z" },
+    { url = "https://files.pythonhosted.org/packages/28/ed/c127d3ac36e899c965e3361357c3befacd6578c03f40125183e41c3b219e/cffi-2.1.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:6ca4919c6e4f89aa99c42510b42cf54596892c00b3f9077f6bdd1505e24b9c8d", size = 208630, upload-time = "2026-07-06T21:33:31.753Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/d7/97d3136f81db489ec8d1d67748c110d6c994268fd7528014aa9f2b085e4e/cffi-2.1.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d53d10f7da99ae46f7373b9150393e9c5eab9b224909982b43832668de4779f5", size = 221593, upload-time = "2026-07-06T21:33:33.044Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/27/93195977168ee63aed233a1a0993a2178798654d1f4bddcdd321d6fd3b21/cffi-2.1.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c351efb95e832a853a29361675f33a7ce53de1a109cd73fd47af0712213aa4ce", size = 225146, upload-time = "2026-07-06T21:33:34.224Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/c1/6dbd291ee2ae5a50a034aa057207081f545923bbf15dad4511e985aafff5/cffi-2.1.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:dbf7c7a88e2bac086f06d14577332760bdeecc42bdec8ac4077f6260557d9326", size = 223240, upload-time = "2026-07-06T21:33:35.57Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/6f/ade5ce9863a57992a6ea3d0d10d7e29b8749fc127204b3d493d667b2815f/cffi-2.1.0-cp314-cp314-win32.whl", hash = "sha256:1854b724d00f6654c742097d5387569021be12d3a0f770eae1df8f8acfcc6acd", size = 177723, upload-time = "2026-07-06T21:33:51.626Z" },
+    { url = "https://files.pythonhosted.org/packages/41/de/92b9eeed4ae4a21d6fd9b2a2c8505cbed573299902ea73981cc13f7ff62c/cffi-2.1.0-cp314-cp314-win_amd64.whl", hash = "sha256:1b96bfe2c4bd825681b7d311ad6d9b7280a091f43e8f63da5729638083cd3bfb", size = 187937, upload-time = "2026-07-06T21:33:53.403Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/1a/cc6ae6c2913a03aab8898eee57963cf1035b8df5872ed8b9115fcc7e2be8/cffi-2.1.0-cp314-cp314-win_arm64.whl", hash = "sha256:7d28dff1db6764108bc30788d85d61c876beff416d9a49cb9dd7c5a9f34f5804", size = 183001, upload-time = "2026-07-06T21:33:54.74Z" },
+    { url = "https://files.pythonhosted.org/packages/14/f0/134c00ce0779ec86dea2aa1aac69339c2741a8045072676763512363a2ea/cffi-2.1.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:7ea6b3e2c4250ff1de21c630fe72d0f63eb95c2c32ffbf64a358cf4a8836d714", size = 188538, upload-time = "2026-07-06T21:33:36.792Z" },
+    { url = "https://files.pythonhosted.org/packages/50/d8/3b86aba791cb610d24e8a3e1b2cd529e71fa15096b04e4d4e360049d4a4c/cffi-2.1.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6af371f3767faeffc6ac1ef57cdfd25844403e9d3f476c5537caee499de96376", size = 188230, upload-time = "2026-07-06T21:33:38.011Z" },
+    { url = "https://files.pythonhosted.org/packages/14/d0/117dcd9209255ad8571fbc8c92ef32593a1d294dcec91ddc4e4db50606f2/cffi-2.1.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:eb4e8997a49aa2c08a3e43c9045d224448b8941d88e7ac163c7d383e560cbf98", size = 223899, upload-time = "2026-07-06T21:33:39.514Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/3d/f20f8b886b254e3ad10e15cd4186d3aed49f3e6a35ab37aab9f8f25f7c03/cffi-2.1.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:bf01d8c84cbea96b944c73b22182e6c7c432b3475632b8111dbfdc95ddad6e13", size = 211652, upload-time = "2026-07-06T21:33:40.851Z" },
+    { url = "https://files.pythonhosted.org/packages/28/3b/fad54de07260b93ddeef4b96d0131d57ea900675df1d410ae1deee52d7a6/cffi-2.1.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:33eb1ad83ebe8f313e0df035c406227d55a79456704a863fad9842136af5ad7d", size = 210755, upload-time = "2026-07-06T21:33:42.183Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/82/3d5c705acb7abbba9bbd7d79b8e62e0f25b6120eb7ae6ac49f1b721722fe/cffi-2.1.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ac0f1a2d0cfa7eea3f2aaf006ab6e70e8feeb16b75d65b7e5939982ca2f11056", size = 223933, upload-time = "2026-07-06T21:33:43.603Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/d0/47e338384ab6b1004241002fa616301020cea4fc95f283506565d252f276/cffi-2.1.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c16914df9fb7f500e440e6875fa23ff5e0b31db01fa9c06af98d59a91f0dc2e4", size = 226749, upload-time = "2026-07-06T21:33:45.046Z" },
+    { url = "https://files.pythonhosted.org/packages/70/25/65bd5b58ea4bfdfc15cde02cb5365f89ef8ab8b2adfb8fe5c4bd4233382f/cffi-2.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5ecbd0499275d57506d397eebe1981cee87b47fcd9ef5c22cab7ed7644a39a94", size = 225703, upload-time = "2026-07-06T21:33:46.374Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/78/aa01ac599a8a4322533d45a1f9bc93b338276d2d59dabbe7c6d92a775c81/cffi-2.1.0-cp314-cp314t-win32.whl", hash = "sha256:7d034dcffa09e9a46c93fa3a3be402096cb5354ac6e41ab8e5cc9cd8b642ad76", size = 182857, upload-time = "2026-07-06T21:33:47.696Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/26/d00496b22de4d4228f32dde94ad996f350c8aad676d63bcca0743c8dea4d/cffi-2.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:0582a58f3051372229ca8e7f5f589f9e5632678208d8636fea3676711fdf7fe5", size = 194065, upload-time = "2026-07-06T21:33:48.953Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/dd/0c7dbf815a579ff005008a2d815a55d6bb047c349eef536d9dc53d3f0a8d/cffi-2.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:510aeeeac94811b138077451da1fb18b308a5feab47dd2b603af55804155e1c8", size = 186404, upload-time = "2026-07-06T21:33:50.309Z" },
+    { url = "https://files.pythonhosted.org/packages/55/c7/8c8c50cb11c6750051daf12164098a9a6f027ac4356967fd4d800a07f242/cffi-2.1.0-cp315-cp315-ios_13_0_arm64_iphoneos.whl", hash = "sha256:2e9dabb9abcb7ad15938c7196ad5c1718a4e6d33cc79b4c0209bdb64c4a54a5c", size = 194121, upload-time = "2026-07-06T21:33:56.109Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e2/67680bf19a6b60d2bb7ff83baefa2a4c3d2d7dc0f3277034b802e1fc504c/cffi-2.1.0-cp315-cp315-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:37f525a7e7e50c017fdebe58b787be310ad59357ae43a053943a6e1a6c526001", size = 196820, upload-time = "2026-07-06T21:33:57.288Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/da/4bbe583a3b3a5c8c60892124fe17f3fa3656523faf0d3484eae90f091853/cffi-2.1.0-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:95f2954c2c9473d892eca6e0409f3568b37ab62a8eedb122461f73cc273476e3", size = 184936, upload-time = "2026-07-06T21:33:58.765Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/4b/1f4c36ab273980d7aa75bb126ea4f8971f24a96108acad3a0a084028c57b/cffi-2.1.0-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:cdf2448aab5f661c9315308ec8b93f4e8a1a67a3c733f8631067a2b67d5913dc", size = 185045, upload-time = "2026-07-06T21:34:00.085Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/c3/ad299dc38f3583f8d916b299f028af418a9ec98bc695fcbebeae7420691c/cffi-2.1.0-cp315-cp315-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:90bec57cf82089383bd06a605b3eb8daebf7e5a668520beaf6e327a83a947699", size = 222342, upload-time = "2026-07-06T21:34:01.814Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/d8/df4543cc087245044ed02ef3ad8e0a26619d0075ac7a77a12dc81177851b/cffi-2.1.0-cp315-cp315-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:6274dcb2d15cef48daa73ed1be5a40d501d74dccd0cd6db364776d12cb6ba022", size = 210073, upload-time = "2026-07-06T21:34:03.255Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/0e/fac738d73728c6cea2a88a2883dca54892496cbba88a1dc1f2909cb8a6f5/cffi-2.1.0-cp315-cp315-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:2b71d409cccee78310ab5dec549aed052aaea483346e282c7b02362596e01bb0", size = 208551, upload-time = "2026-07-06T21:34:04.433Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/3f/0b04a700dd64f465c93020253a793a82c9b4dff9961f48facd0df945d9b8/cffi-2.1.0-cp315-cp315-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7d3538f9c0e50670f4deb93dbb696576e60590369cae2faf7de681e597a8a1f1", size = 221649, upload-time = "2026-07-06T21:34:06.157Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/7c/b7379a5704c79eda57ce075869ba70a0368d1c850f803b3c0d078d39dcaf/cffi-2.1.0-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:8f9ec95b8a043d3dfbc74d9abc6f7baf524dd27a8dc160b0a32ff9cdab650c28", size = 225203, upload-time = "2026-07-06T21:34:07.489Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/02/d5e6c43ea85c41bda2a184a3418f195fe7cf602967a8d2b94e085b83deef/cffi-2.1.0-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:af5e2915d41fe6c961694d7bfdc8562942638200f3ce2765dfb8b745cf997629", size = 223263, upload-time = "2026-07-06T21:34:08.712Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/d8/772b8259bf75749adffb1c546828978381fb516f60cf701f6c83daf60c85/cffi-2.1.0-cp315-cp315-win32.whl", hash = "sha256:0a42c688d19fca6e095a53c6a6e2295a5b050a8b289f109adab02a9e61a25de6", size = 177696, upload-time = "2026-07-06T21:34:26.355Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/dd/afa2191fc6d57fedd26e5844a2fe2fcc0bbfa00961bbaa5a41e4921e7cca/cffi-2.1.0-cp315-cp315-win_amd64.whl", hash = "sha256:bccbbb5ee76a61f9d99b5bf3846a51d7fca4b6a732fe46f89295610edaf41853", size = 187914, upload-time = "2026-07-06T21:34:27.58Z" },
+    { url = "https://files.pythonhosted.org/packages/05/ef/6cd4f8c671517162379dc79cfae5aea9106bc38abb89628d5c16adf6a838/cffi-2.1.0-cp315-cp315-win_arm64.whl", hash = "sha256:8d35c139744adb3e727cd51b1a18324bbe44b8bd41bf8322bca4d41289f48eda", size = 183004, upload-time = "2026-07-06T21:34:28.905Z" },
+    { url = "https://files.pythonhosted.org/packages/11/b6/12fc55092817a5faa26fb8c40c7f9d662e11a46ee248c137aafc42517d92/cffi-2.1.0-cp315-cp315t-macosx_10_15_x86_64.whl", hash = "sha256:f9912624a0c0b834b7520d7769b3644453aabc0a7e1c839da7359f050750e9bc", size = 188378, upload-time = "2026-07-06T21:34:09.926Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/2e/cdac88979f295fde5daa69622c7d2111e56e7ceb94f211357fbe452339e4/cffi-2.1.0-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:df92f2aba50eb4d96718b68ef76f2e57a57b54f2fa62333496d16c6d585a85ca", size = 188319, upload-time = "2026-07-06T21:34:11.101Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/27/1d0b408497e41a74795af122d7b603c418c5fed0171450f899afd04e594f/cffi-2.1.0-cp315-cp315t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0520e1f4c35f44e209cbbb421b67eec42e6a157f59444dfb6058874ff3610e5d", size = 223904, upload-time = "2026-07-06T21:34:12.606Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/31/e115c985105dd7ffb32444505f18ceb874bb42d992af05d5dced7ecf1980/cffi-2.1.0-cp315-cp315t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:3681e031db29958a7502f5c0c9d6bbc4c36cb20f7b104086fa642d1799631ff8", size = 211554, upload-time = "2026-07-06T21:34:13.987Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/67/9e6e09409336d9e515c58367e7cfcf4f89df06ad25252675595a58eb59d5/cffi-2.1.0-cp315-cp315t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:762f99479dcb369f60ab9017ad4ab97a36a1dd7c1ee5a3b15db0f4b8659120cd", size = 210795, upload-time = "2026-07-06T21:34:15.972Z" },
+    { url = "https://files.pythonhosted.org/packages/19/e5/d3cc82a4a0be7902af279c04181ad038449c096734464a5ae1de3e1401bd/cffi-2.1.0-cp315-cp315t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0611e7ebf90573a535ebdc33ae9da222d037853983e13359f580fab781ca017f", size = 223843, upload-time = "2026-07-06T21:34:17.509Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/65/b434abc97ce7cecc2c640fde160507c0ecc7e21544b483ba3325d2e2ea17/cffi-2.1.0-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:86cf8755a791f72c85dc287128cc62d4f24d392e3f1e15837245623f4a33cccc", size = 226773, upload-time = "2026-07-06T21:34:19.05Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/9f/d4dc66ca651eb1145a133314cda721abf13cfac3d28c4a0402263ae6ad75/cffi-2.1.0-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:ba00f661f8ba35d075c937174e27c2c421cec3942fd2e0ea3e66996757c0fdd9", size = 225719, upload-time = "2026-07-06T21:34:20.576Z" },
+    { url = "https://files.pythonhosted.org/packages/68/5a/e536c528bc8057496c360c0978559a2dc45653f89dd6151078aa7d8fca1a/cffi-2.1.0-cp315-cp315t-win32.whl", hash = "sha256:cb96698e3c7413d906ce83f8ffd245ec1bd94707541f299d0ce4d6b0193e982b", size = 182760, upload-time = "2026-07-06T21:34:22.059Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/0b/0ffe8b82d3875bced5fa1e7986a7a46b748262a40ab7f60b475eb9fb1bb3/cffi-2.1.0-cp315-cp315t-win_amd64.whl", hash = "sha256:f146d154428a2523f9cc7936c02353c2459b8f6cf07d3cd1ee1c0a611109c5d5", size = 193769, upload-time = "2026-07-06T21:34:23.589Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/17/1073b53b68c9b5ca6914adf5f8bf55aacc2d3be102418c90700160ea8605/cffi-2.1.0-cp315-cp315t-win_arm64.whl", hash = "sha256:cbb7640ce37159548d2147b5b8c241f962143d4c71231431820783f4dc78f210", size = 186405, upload-time = "2026-07-06T21:34:24.857Z" },
+]
+
+[[package]]
 name = "charset-normalizer"
 version = "3.4.7"
 source = { registry = "https://pypi.org/simple" }
@@ -318,11 +410,61 @@ wheels = [
 ]
 
 [[package]]
+name = "cryptography"
+version = "49.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/99/d1c90d6041656cc6ee229dc99cd67fd0cd5aec3c5f7d72fffc27cc750054/cryptography-49.0.0.tar.gz", hash = "sha256:f89660a348f4f78a92366240a61404e337586ef7f5909a2fef59ca88ef505493", size = 854345, upload-time = "2026-06-12T20:02:30.512Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/22/adf66990e63584a68dfb50c24f48a125c07b1699899381c8151e63ed458c/cryptography-49.0.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:966fe0e9c67490071f14c0d2b1cb2dfb3023c5ce39457343931415f08382f2db", size = 4032100, upload-time = "2026-06-12T20:02:32.143Z" },
+    { url = "https://files.pythonhosted.org/packages/09/41/3797cfaf69cae04a13ee78ebd83f0678d9c02b4779d21ce24445326f1a69/cryptography-49.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:36d1709f992593689b45bda411498d62c6e365f2ca00b84657d4dadd24de16db", size = 4692978, upload-time = "2026-06-12T20:01:21.305Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/8b/43011f7ebe515a8aa20d61f290a326cd890c2e738e16e59eaff8d9c3a412/cryptography-49.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0e959b578856a3924bc0cbb710fc12c387b9412a951389f3ca61704a9e25f325", size = 4716422, upload-time = "2026-06-12T20:01:48.566Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/91/01ce7303a4579e6d3a6abef01bd322848e9ea7a219adcabc5048b9033571/cryptography-49.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:53ecee2e23f7169b6117e99fc8a944e5e50f79e69758a83b52a00cb98ab2b2d2", size = 4700503, upload-time = "2026-06-12T20:02:47.091Z" },
+    { url = "https://files.pythonhosted.org/packages/62/99/a2c95cf8293f07491e9e27c20cc4dcd18176d944e674679adeb1d0173fd6/cryptography-49.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:2eda353d8a27bcbcaa4cbed18994a74ab4d19a2ca897db188ea269ab9b71419b", size = 5309779, upload-time = "2026-06-12T20:02:08.987Z" },
+    { url = "https://files.pythonhosted.org/packages/20/2c/0622f20ff02b2ef32558733443805dc82fd4c275be01b2d19d14676f3a1b/cryptography-49.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2afe9051da7ae7bd5905da5a949280c7d2bb75682e188f650a9d0f2756b834c6", size = 4749683, upload-time = "2026-06-12T20:02:03.335Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5b/c5246635d5fd3b64e0d45ae10e99fd32fe9676a79915ccfe5a61ba9af1a5/cryptography-49.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:0b82e28ee398a386f0807bba7884d30f25218855690f45115831bcce5d90822c", size = 4337874, upload-time = "2026-06-12T20:02:54.323Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/88/05563c7fe2e914e87d1a536d06fe83e66b4e1d95cb593e05aea375531da8/cryptography-49.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:ccac2bfebc306b862133e3bb71f3f6ee8bb525240089b2d952e4144b3a6d5da7", size = 4700283, upload-time = "2026-06-12T20:01:34.822Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/b6/d7696e4e890d6ae1469935164c9e5215c557671cb78d6e3f458ccceaa632/cryptography-49.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:d0527ce944105f257f605a827d6ebead966c752038b6e8656abb9c5edee6fc68", size = 5265844, upload-time = "2026-06-12T20:01:24.09Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/3c/f3ad17eecc1a57b0ba236dc01f90e783c51f4a2f35f64777cc4f47a184b2/cryptography-49.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:cbc77da8c523d5abd028635ba850a6966fcee2c82e2bf65a41d1d8afe0f98be9", size = 4749290, upload-time = "2026-06-12T20:01:30.848Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/01/339573cf1023163a400b0b5d16f6d507de413b9f60be6fd1b77feeaf6737/cryptography-49.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:b87e65d263b3e5d3bb92a57e2a6638e2f31110fa7aa890c7b2dbba42248d0a3f", size = 4834612, upload-time = "2026-06-12T20:01:29.246Z" },
+    { url = "https://files.pythonhosted.org/packages/71/fd/577302e213a1be9468f92d1afef66fcf1ef83d516819d9992ca547f592bd/cryptography-49.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:66ec79c3904820572d7e987abdf304281f141d37ad9a489b8e97066e7b9b6459", size = 4980804, upload-time = "2026-06-12T20:01:42.853Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/09/f42b1d190c5ba75f72062a387f8030d1d75f6ab035788f1d9c4b01de6525/cryptography-49.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:e5dfc1e64de5677cec922ffa8da89c546d0415bf6efdf081842e5d44c84e1f0e", size = 3810026, upload-time = "2026-06-12T20:02:39.262Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/9e/db72b3ae7fc9cfad53e630e56c6ae83b9b6ff0bf3718ffb8012d20b3aabf/cryptography-49.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:73a205dce83953d131a4aa1e0fd917a2fd1c5b1eef251e9d7152efefcbf5caf7", size = 4013892, upload-time = "2026-06-12T20:02:10.735Z" },
+    { url = "https://files.pythonhosted.org/packages/86/12/c48a424f38db03027be9f7ed5c7dc5de9933dbee992865f98b13727a009d/cryptography-49.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:196ecd6a36e4e9aa10270393bb98d8df88fccee0bf1e5128b91ae4eb4375896d", size = 4678835, upload-time = "2026-06-12T20:02:48.743Z" },
+    { url = "https://files.pythonhosted.org/packages/68/28/8a3ad4653662c93fc44dc4e5d8fd374c25c42e07b34bbfbadf49cf57a5a8/cryptography-49.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7abcee80084cda3f7691f3eb1ce480d8df49cec637b429aa35986c1de71738aa", size = 4697239, upload-time = "2026-06-12T20:02:56.03Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/b2/2193fc74f81aee4f9b62733133b73b5176718932ed8f2e4b03fa040480a6/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:4ae387c9cb68ea569ca17e490d66d8142b81c3cc814bf179974b7d146e490bbb", size = 4685593, upload-time = "2026-06-12T20:02:50.666Z" },
+    { url = "https://files.pythonhosted.org/packages/47/f1/1d3eaa243bfc5de4a187b22aa8c048b3e4980bfbe830ac46e6bac2e66947/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:f37d847238971164fdbc68ade6f6574aecc9c0af714190e2083429ff68f4ce9d", size = 5289961, upload-time = "2026-06-12T20:01:46.468Z" },
+    { url = "https://files.pythonhosted.org/packages/58/39/2d51306721330c486495853eda1c567880ff036de15a14c4b74f399934af/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:c2bc30226390d60ea19d9f82b19db005fe0452154a23c1c410c12ea801e43561", size = 4731145, upload-time = "2026-06-12T20:02:16.832Z" },
+    { url = "https://files.pythonhosted.org/packages/17/50/983e838c7fd0d87fd8c969bcdd328edaf5f756e38df5281637424c155873/cryptography-49.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:07cab27cc7b7e0fd28e5e26bb9eeedde5c135c868b46de4a27845abe94af6122", size = 4321719, upload-time = "2026-06-12T20:02:52.611Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/f5/8f571d7e27c55bce9f76f026143bcb1e040a4233149ecca0bea5fa5dd5f7/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:b20133d204d2bb56ba047642199603876c872026ca53e79c35b83772ab2cc505", size = 4685209, upload-time = "2026-06-12T20:02:07.282Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/84/0e27016a6fc5a0886f797018b26aa42f40c09a82332bff77822a451deaaa/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:b970c6da94d5bb18629db453d14f2a1300f6bf59b61e9b82377931ef95504866", size = 5246285, upload-time = "2026-06-12T20:01:32.439Z" },
+    { url = "https://files.pythonhosted.org/packages/11/2d/5e1fb307cb5931881516b464c98774b3f2c36b5d4bb9a2830253cf553cad/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:d8ecde755e2e91bf773fc94e8c9d730cd7f2007004cb492263a794ec3899a1c8", size = 4730441, upload-time = "2026-06-12T20:02:01.469Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/c0/bff5a02ee731d207d6a1ed51732549d8c53d2bc8da1d10ec6f2844201d68/cryptography-49.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e3fb64c420688e5319ae25113a354015abbd8dffbfbc41781a1ea66fc7622ac3", size = 4815869, upload-time = "2026-06-12T20:01:36.574Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/26/814681d14248d95d73d5c3eea0c39a94eb8302df966f670a2c60de90974b/cryptography-49.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32703d93296f5c1f4b53349ad3a250c2cae0fdecd3a3dd5d47e616d8d616af27", size = 4960948, upload-time = "2026-06-12T20:02:18.688Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/fe/93ecac273d3738939d023612ad12cca9a3740a5345d69fda04134c43fd96/cryptography-49.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:33cd0565932807baddb67b96dbee92f2c374b5c89dee09fd74079aeb8c8dba61", size = 3799153, upload-time = "2026-06-12T20:01:39.059Z" },
+    { url = "https://files.pythonhosted.org/packages/19/2a/5bb823f5bedcf80718cea7fbc95ec5515cca3769633c4b01a32be7f30e7c/cryptography-49.0.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ec5e529fb80935c94fe7b729f9972b50e351a0e6b50aa294fd5cabb109fcc29a", size = 4025947, upload-time = "2026-06-12T20:01:25.745Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/df/40577043ca124e17012f408ddddaeb213b856336ac82ddb3bc915f39e29f/cryptography-49.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f78ff2c9ed8dc2d036b0f4d640e22522213d047c1b14e61205a7e55c80a494d4", size = 4692429, upload-time = "2026-06-12T20:01:53.628Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/99/2d13299eb3dd27b02dcfaafcc91d6b5cb3329f7cbd6d8f51921acd566c1a/cryptography-49.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:35b151772baff2c74cba7fa290ceaff4c3b11c0c881eb93eb5dbc05a7cfbba18", size = 4700968, upload-time = "2026-06-12T20:02:45.383Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/4d/9c0cd02f95e2602dd5e563da149ee0830abef3537be8b34dc56281ebe27a/cryptography-49.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:0f21641cf4b30fca7aee061ced0ec7ad7b073518088b7c9969a297c0ae796c69", size = 4697758, upload-time = "2026-06-12T20:01:41.13Z" },
+    { url = "https://files.pythonhosted.org/packages/24/01/186c825898477d77e2324d5360fefe622ff1d8d1963ec0554e2cada8ec77/cryptography-49.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:9e82dcc8e56052715fb18b2429e3bca4823b1629136a2084fc45a9a5cecb9b64", size = 5298863, upload-time = "2026-06-12T20:02:24.579Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/7b/62cbbab75d0659865bf0273790031544a0b16c8072d258f9428dcd8190dc/cryptography-49.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:6f2debedf9ca60cf1d5bd466475638af5130f89965605cd818484d19987d3a21", size = 4735983, upload-time = "2026-06-12T20:01:50.14Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/72/3e798c064bc39e471008075d0f9bc9daf77a80879c092e4a8e170c585ed4/cryptography-49.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:8c25ceb16df5b9435f3f6a9829204985b0e0cbee3b48aacd432c7d2c850b44d9", size = 4334173, upload-time = "2026-06-12T20:01:44.743Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/ee/6fca21d1ac73e06f8bef71940abfd4d2f6472b4bca284d770f32bd4086f6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:28d8b15e6275f12c8a207dc309dfa957903c927d08d0cc937ee3f63f200693cc", size = 4697298, upload-time = "2026-06-12T20:02:20.918Z" },
+    { url = "https://files.pythonhosted.org/packages/67/d0/a5fcd3515f0bae49a7b6d0413cc1bdccdcc1fc0047037a0d480642cdc5d6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:6fc361c34fb6aac015ce19435876635e5c6d21db31998b0920f675f131e043b8", size = 5254338, upload-time = "2026-06-12T20:02:22.737Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/84/84fe36f19caf857d61cb7fc9c63035a47ffabd84ea12d1d393148efa3615/cryptography-49.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:2400ef9c9e2299a25614eb1dea3db54a69b1349efd043bfac9c67630d136df36", size = 4735650, upload-time = "2026-06-12T20:02:41.389Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/a0/db537264e234f7273a73ec020873d6d6b39dfd8a53db78b550ca8320440e/cryptography-49.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:67e1d20ad9ef3a563c59ef22e7a8a0b8210bd26604369ea4a30a7c66aefe504e", size = 4834820, upload-time = "2026-06-12T20:01:51.847Z" },
+    { url = "https://files.pythonhosted.org/packages/93/77/8df9eb486495979bccecd1062e2eaf435250e84437040295b57d09048b0b/cryptography-49.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:42b0684e0e40cf26122427802486f6d93aea593612603a94fbf260c7eb1e9c1b", size = 4967968, upload-time = "2026-06-12T20:02:12.524Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/e6/f60198ea8d9dfa15fff9ed4ca02ce362f6eadd9ba757dcc50634c4257b63/cryptography-49.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:026ac7423e6fa66872d3bf889be5974507da3944f866f704fa200eadacd00001", size = 3785547, upload-time = "2026-06-12T20:02:26.847Z" },
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "13.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder" },
+    { name = "cuda-pathfinder", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cc/6e/2394f8163360f8391f8f1b7e72d300a82724edb81a7b7084c799fbd4c91f/cuda_bindings-13.3.1-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9efb21c1ee64981e184b9e0ba5eb3179e5ba3d4b51665a6cb52b8ef3d01a7cbf", size = 5920504, upload-time = "2026-05-29T23:11:56.883Z" },
@@ -351,34 +493,34 @@ wheels = [
 
 [package.optional-dependencies]
 cudart = [
-    { name = "nvidia-cuda-runtime", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cuda-runtime", marker = "sys_platform == 'linux'" },
 ]
 cufft = [
-    { name = "nvidia-cufft", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cufft", marker = "sys_platform == 'linux'" },
 ]
 cufile = [
     { name = "nvidia-cufile", marker = "sys_platform == 'linux'" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cuda-cupti", marker = "sys_platform == 'linux'" },
 ]
 curand = [
-    { name = "nvidia-curand", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-curand", marker = "sys_platform == 'linux'" },
 ]
 cusolver = [
-    { name = "nvidia-cusolver", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cusolver", marker = "sys_platform == 'linux'" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cusparse", marker = "sys_platform == 'linux'" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux'" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cuda-nvrtc", marker = "sys_platform == 'linux'" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-nvtx", marker = "sys_platform == 'linux'" },
 ]
 
 [[package]]
@@ -388,6 +530,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
+name = "docstring-parser"
+version = "0.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015", size = 29341, upload-time = "2026-04-14T04:09:19.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484, upload-time = "2026-04-14T04:09:18.638Z" },
 ]
 
 [[package]]
@@ -754,6 +905,56 @@ wheels = [
 ]
 
 [[package]]
+name = "jiter"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1d/1f/10936e16d8860c70698a1aa939a46aa0224813b782bce4e000e637da0b2d/jiter-0.16.0.tar.gz", hash = "sha256:7b24c3492c5f4f84a37946ad9cf504910cf6a782d6a4e0689b6673c5894b4a1c", size = 176431, upload-time = "2026-06-29T13:05:13.657Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/91/c0/555fc60473d30d66894ba825e63615e3be7524fac23858356afa7a38906c/jiter-0.16.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:41977aa5654023948c2dae2a81cbf9c43343954bef1cd59a154dd15a4d84c195", size = 306203, upload-time = "2026-06-29T13:03:36.243Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/2b/c3eaf16f5d7c9bad66ea32f40a95bd169b29a91217fcc7f081375157e99c/jiter-0.16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d28bb3c26762358dadf3e5bf0bccd29ae987d65e6988d2e6f49829c76b003c09", size = 306489, upload-time = "2026-06-29T13:03:37.846Z" },
+    { url = "https://files.pythonhosted.org/packages/96/3f/02fdfc6705cad96127d883af5c34e4867f554f29ec7705ec1a46156400a9/jiter-0.16.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0542a7189c26920778658fc8fcf2af8bae05bae9924577f71804acef37996536", size = 335453, upload-time = "2026-06-29T13:03:39.221Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/a6/e4bda5920d4b0d7c5dfb7174ce4a6b2e4d3e11c9162c452ef0eab4cdbdbd/jiter-0.16.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8fb8de1e23a0cb2a7f53c335049c7b72b6db41aa6227cdcc0972a1de5cb39450", size = 361625, upload-time = "2026-06-29T13:03:40.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/97/4e6b59b2c6e55cbb3e183595f81ad65dcfb21c915fee5e19e335df21bc55/jiter-0.16.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b72d0b2990ca754a9102779ac98d8597b7cb31678958562214a007f909eab78e", size = 456958, upload-time = "2026-06-29T13:03:42.074Z" },
+    { url = "https://files.pythonhosted.org/packages/15/e0/97e9557686d2f94f4b93786eccb7eed28e9228ad132ea8237f44727314a7/jiter-0.16.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d5f91b1c27fc22a57993d5a5cb8a627cb8ed4b10502716fac1ffbfe1d19d84e8", size = 372017, upload-time = "2026-06-29T13:03:43.658Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/94/db768b6938e0df35c86beeba3dfbbb025c9ee5c19e1aa271f2396e50864d/jiter-0.16.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c682bea068a90b764577bdb78a60a4c1d1606daf9cd4c893832a37c7cc9d9026", size = 343320, upload-time = "2026-06-29T13:03:45.226Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/d6/5a59d938244a30735fe62d9433fd325f9021ea29d89780ea4596ea93bc89/jiter-0.16.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:8d031aabecc4f1b6276adfb42e3aabb77c89d468bf616600e8d3a11328929053", size = 350520, upload-time = "2026-06-29T13:03:46.671Z" },
+    { url = "https://files.pythonhosted.org/packages/67/f8/c4a857f49c9af125f6bbcac7e3eee7f7978ed89682833062e2dbf62576b1/jiter-0.16.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:eab2cd170150e70153de16896a1774e3a1dca80154c56b54d7a812c479a7165e", size = 387550, upload-time = "2026-06-29T13:03:48.361Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/d6/5fbc2f7d6b67b754caa61a993a2e626e815dec47ffc2f9e35f01adfebec7/jiter-0.16.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:6edb63a46e65a82c26800a868e49b2cac30dd5a4218b88d74bc2c848c8ad60bb", size = 515424, upload-time = "2026-06-29T13:03:49.881Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/54/284f0164b64a5fed915fea6ba7e9ba9b3d8d37c67d59cf2e3bb99d45cdfe/jiter-0.16.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:659039cc50b5addcc35fcc87ae2c1833b7c0a8e5326ef631a75e4478447bcf84", size = 546981, upload-time = "2026-06-29T13:03:51.363Z" },
+    { url = "https://files.pythonhosted.org/packages/13/c5/2a467585a576594384e1d2c43e1224deaafc085f24e243529cf98beef8e1/jiter-0.16.0-cp313-cp313-win32.whl", hash = "sha256:c9c53be232c2e206ef9cdbad81a48bfa74c3d3f08bcf8124630a8a748aad993e", size = 202853, upload-time = "2026-06-29T13:03:53.015Z" },
+    { url = "https://files.pythonhosted.org/packages/88/6a/de61d04b9eec69c71719968d2f716532a3bc121170c44a39e14979c6be81/jiter-0.16.0-cp313-cp313-win_amd64.whl", hash = "sha256:baad945ed47f163ad833314f8e3288c396118934f94e7bbb9e243ce4b341a4fd", size = 196160, upload-time = "2026-06-29T13:03:54.447Z" },
+    { url = "https://files.pythonhosted.org/packages/19/4b/b390ed59bafb3f31d008d1218578f10327714484b334439947f7e5b11e7f/jiter-0.16.0-cp313-cp313-win_arm64.whl", hash = "sha256:3c1fd2dbe1b0af19e987f03fe66c5f5bd105a2229c1aff4ab14890b24f41d21a", size = 189862, upload-time = "2026-06-29T13:03:55.754Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/89/bc4f1b57d5da938fd344a466396541e586d161320d70bffd929aaafcd8f4/jiter-0.16.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:b2c61484666ad42726029af0c00ef4541f0f3b5cdc550221f56c2343208018ee", size = 308239, upload-time = "2026-06-29T13:03:57.205Z" },
+    { url = "https://files.pythonhosted.org/packages/65/7a/c415453e5213001bf3b411ff65dec3d303b0e76a4a2cfea9768cd4960994/jiter-0.16.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:63efadc657488f45db1c676d81e704cac2abf3fdb892def1faea61db053127e2", size = 308928, upload-time = "2026-06-29T13:03:58.643Z" },
+    { url = "https://files.pythonhosted.org/packages/11/fc/1f4fb7ebf9a724c7741994f4aae18fba1e2f3133df14521a79194952c34a/jiter-0.16.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cf0d73f50e7b6935677854f6e8e31d499ca7064dd24734f703e060f5b237d883", size = 336998, upload-time = "2026-06-29T13:04:00.071Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/8d/72cadaac05ccfa7cc3a0a2232862e6c72443ca40cf300ba8b57f9f18b69b/jiter-0.16.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bf3ea07d9bc8e7d03a9fbc051295462e6dbc295b894fd72457c3136e3e43d898", size = 362112, upload-time = "2026-06-29T13:04:01.52Z" },
+    { url = "https://files.pythonhosted.org/packages/58/4a/c4b0d5f651fda90a24ffce9f8d56cde462a2e09d31ae3de3c68cef34c04e/jiter-0.16.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:26798522707abb47d767db536e4148ceac1b14446bf028ee85e579a2e043cfe5", size = 459807, upload-time = "2026-06-29T13:04:03.214Z" },
+    { url = "https://files.pythonhosted.org/packages/80/58/ef77879ea9aa56b50824edc5a445e226422c7a8d211f3fd2a56bcb9493cf/jiter-0.16.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bc837c1b9631be10abfe0191537fe8009838204cec7e44827401ace390ddb567", size = 373181, upload-time = "2026-06-29T13:04:04.629Z" },
+    { url = "https://files.pythonhosted.org/packages/49/2e/ffbc3f254e4d8a66da3062c624a7df4b7c2b2cf9e1fe43cf394b3e104041/jiter-0.16.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:49060fd70737fad59d33ba9dcc0d83247dc9e77187de26053a19c16c9f32bd69", size = 344927, upload-time = "2026-06-29T13:04:06.067Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/f6/0be5dc6d64a89f80aa8fec984f94dedb2973e251edcae55841d60786d578/jiter-0.16.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:adbb8edeadd431bc4477879d5d371ece7cb1334486584e0f252656dd7ffada29", size = 352754, upload-time = "2026-06-29T13:04:07.477Z" },
+    { url = "https://files.pythonhosted.org/packages/da/6e/7d31243b3b91cd261dd19e9d3557fc3251a80883d3d8049c86174e7ab7af/jiter-0.16.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:31aaee5b80f672c1dc21272bcfb9cbdcfc1ea04ff50f00ed5af500b80c44fa93", size = 390553, upload-time = "2026-06-29T13:04:08.92Z" },
+    { url = "https://files.pythonhosted.org/packages/25/33/51ae371fde3c88897520f62b4d5f8b27ad7103e2bb10812ff52195609853/jiter-0.16.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:6722bcef4ffc86c835574b1b2fac6b33b9fb4a889c781e67950e891591f3c55a", size = 516900, upload-time = "2026-06-29T13:04:10.407Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/45/6449b3d123ea439ba79507c657288f461d55049e7bcbdc2cf8eb8210f491/jiter-0.16.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:5ab4f50ff971b611d656554ea10b75f80097392c827bc32923c6eeb6386c8b00", size = 548754, upload-time = "2026-06-29T13:04:12.046Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/e7/fd2fb11ae3e2649333da3aa170d04d7b3000bbdc3b270f6513382fdf4e04/jiter-0.16.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:710cc51d4ebdcd3c1f70b232c1db1ea1344a075770422bbd4bede5708335acbe", size = 122381, upload-time = "2026-06-29T13:04:13.413Z" },
+    { url = "https://files.pythonhosted.org/packages/26/80/f0b147a62c315a164ed2168908286ca302310824c218d3aae52b06c0c9a9/jiter-0.16.0-cp314-cp314-win32.whl", hash = "sha256:57b37fc887a32d44798e4d8ebfa7c9683ff3da1d5bf38f08d1bb3573ccb39106", size = 204578, upload-time = "2026-06-29T13:04:14.813Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/e6/4758a14304b4523a6f5adb2419340086aa3593bd4327c2b25b5948a90548/jiter-0.16.0-cp314-cp314-win_amd64.whl", hash = "sha256:cbd18dd5e2df96b580487b5745adf57ef64ad89ba2d9662fc3c19386acce7db8", size = 198154, upload-time = "2026-06-29T13:04:16.272Z" },
+    { url = "https://files.pythonhosted.org/packages/26/be/41fa54a2e7ea41d6c99f1dc5b1f0fd4cb474680304b5d268dd518e81da3a/jiter-0.16.0-cp314-cp314-win_arm64.whl", hash = "sha256:a32d2027a9fa67f109ff245a3252ece3ccc32cc56703e1deab6cc846a59e0585", size = 191458, upload-time = "2026-06-29T13:04:17.707Z" },
+    { url = "https://files.pythonhosted.org/packages/81/6b/59127338b86d9fe4d99418f5a15118bea778103ee0fe9d9dd7e0af174e95/jiter-0.16.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:2577196f4474ef3fc4779a088a23b0897bbf86f9ea3679c372d45b8383b43207", size = 316739, upload-time = "2026-06-29T13:04:19.663Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/95/49461034d5388196d3dabf98748935f017b7785d8f3f5349f834bcc4ed0d/jiter-0.16.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:616e89e008a93c01104161c75b4988e58716b01d62307ebfe161e52a56d2a818", size = 340911, upload-time = "2026-06-29T13:04:21.257Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/97/a4369f2fb82cb3dda13b98622f31249b2e014b223fe64ee534413ad72294/jiter-0.16.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0e2e9efbe042210df657bade597f66d6d75723e3d8f45a12ea6d8167ff8bbce3", size = 361747, upload-time = "2026-06-29T13:04:22.677Z" },
+    { url = "https://files.pythonhosted.org/packages/28/51/49b6ed456261646e1906016a6760367a28aacd3c24805e4e5fe64116c1db/jiter-0.16.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3f4d9e473a5ce7d27fef8b848df4dc16e283893d3f53b4a585e72c9595f3c284", size = 460225, upload-time = "2026-06-29T13:04:24.441Z" },
+    { url = "https://files.pythonhosted.org/packages/33/b5/5689aff4f66c5b60be63106e591dbfcba2190df97d2c9c7cf052361ddb98/jiter-0.16.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8d30a4a1c87713060c8d1cc59a7b6c8fb6b8ef0a6900368014c76c87922a2929", size = 373169, upload-time = "2026-06-29T13:04:25.884Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/96/3ae1b85ee0d6d6cab254fb7f8da018272b932bbf2d69b07e98aa2a96c746/jiter-0.16.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bae96332410f866e5900d809298b1ed82735932986c672495f9701daacd80620", size = 350332, upload-time = "2026-06-29T13:04:27.302Z" },
+    { url = "https://files.pythonhosted.org/packages/15/32/c99d7bafd78986556c95bf60ce84c6cc98786eac56066c12d7f828bb6747/jiter-0.16.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:da3d7ec75dc83bb18bca888b5edfae0656a26849056c59e05a7728badd17e7af", size = 353377, upload-time = "2026-06-29T13:04:28.731Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/4b/f99a8e571287c3dec766bcc18528bbe8e8fb5365522ab5e6d64c93e87066/jiter-0.16.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ee6162b77d49a9939229df666dfa8af3e656b6701b54c4c84966d740e189264e", size = 387746, upload-time = "2026-06-29T13:04:30.319Z" },
+    { url = "https://files.pythonhosted.org/packages/75/69/c78a5b3f71040e34eb5917df26fb7ae9a2174cad1ccbf277512507c53a6e/jiter-0.16.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:63ffdbdae7d4499f4cda14eadc12ddcabef0fc0c081191bdc2247489cb698077", size = 517292, upload-time = "2026-06-29T13:04:31.709Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/f7/095b38eda4c70d03651c403f29a5590f16d12ddc5d544aac9f9cddf72277/jiter-0.16.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:a111256a7193bea0759267b10385e5870949c239ed7b6ddbaaf57573edb38734", size = 549259, upload-time = "2026-06-29T13:04:33.721Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/c5/6a0207d90e5f656d95af98ebd0934f382d37674416f215aeda2ff8063e51/jiter-0.16.0-cp314-cp314t-win32.whl", hash = "sha256:de5ba8763e56b793561f43bed197c9ea55776daa5e9a6b91eed68a909bc9cdbf", size = 206523, upload-time = "2026-06-29T13:04:35.068Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/31/c757d5f30a8980fd945ce7b98be10be9e4ff59c7c42f5fd86804c2e87db8/jiter-0.16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b8a3f9a6008048fe9def7bf465180564a6e458047d2ce499149cfbe73c3ae9db", size = 200366, upload-time = "2026-06-29T13:04:36.61Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/a2/d88de6d313d734a544a7901353ad5db67cb38dcfcd91713b7979dafc345d/jiter-0.16.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0fa25b09b13075c46f5bc174f2690525a925a4fc2f7c82969a2bbabff22386ce", size = 190516, upload-time = "2026-06-29T13:04:38.004Z" },
+]
+
+[[package]]
 name = "joblib"
 version = "1.5.3"
 source = { registry = "https://pypi.org/simple" }
@@ -822,6 +1023,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/56/7c/651d0dc4913a7a892156c03dd343b99cfe19ee729e6911ab1f4fe7567b8b/langchain-1.3.9.tar.gz", hash = "sha256:9b14ef0db9ef314299ded858b22ca2a40b8f1b05c8c9cb6b82d53a53075fef00", size = 631514, upload-time = "2026-06-12T16:53:27.083Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/55/3481619d21b9bdfbfda8680fba5cfc6cfe926789b8eaaad95353078cfa20/langchain-1.3.9-py3-none-any.whl", hash = "sha256:4af49ad1095799e4408b489fb79d4b8b49292453618b202d8a697fca59bb6871", size = 132873, upload-time = "2026-06-12T16:53:25.489Z" },
+]
+
+[[package]]
+name = "langchain-anthropic"
+version = "1.4.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anthropic" },
+    { name = "langchain-core" },
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/98/22/40ab129b08329ca295b391aa1d48267692b42594757084c6918e22b655ac/langchain_anthropic-1.4.8.tar.gz", hash = "sha256:c76891b2044d56105ff13c106ed12650637b53bd598a4bdf15b4796eefa2a4ec", size = 708524, upload-time = "2026-06-26T21:28:46.916Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/14/746235c4da89d9bc6a608c5f489f628e03feb8f697195c146e452c8f23c8/langchain_anthropic-1.4.8-py3-none-any.whl", hash = "sha256:778e9301b6fd517824f76ec1776975ce8add97a1f6a36c50ae3c2f4b03a66f7f", size = 52366, upload-time = "2026-06-26T21:28:45.535Z" },
 ]
 
 [[package]]
@@ -909,6 +1124,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/2c/e8/4068ad02179253f55958e59e442e5b6e8cb95ffc5e805cc4db0b1ef61d4e/langchain_huggingface-1.2.2.tar.gz", hash = "sha256:1dd91ec415190d2704e93ec149618e3145075863ba37e74afc9080d685dc2743", size = 255513, upload-time = "2026-04-16T19:57:41.046Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0a/ed/648b87f9b67153ade616f360bf4145b76ed428b4adb89525938f611e9828/langchain_huggingface-1.2.2-py3-none-any.whl", hash = "sha256:f94944b0c0d5afc687568d426c87ed5236907464c41e72108ed76eee1a690f6d", size = 31926, upload-time = "2026-04-16T19:57:40.079Z" },
+]
+
+[[package]]
+name = "langchain-openai"
+version = "1.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "langchain-core" },
+    { name = "openai" },
+    { name = "tiktoken" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d0/f3/b38e052f943a75ba0e6762c0a50b6f1d6bcd52a9ce63386d8803c2ff506e/langchain_openai-1.3.3.tar.gz", hash = "sha256:143769bf943820b80db769e47ca8fd0aac08ed18714519333b044c4431e9aa67", size = 3256559, upload-time = "2026-06-22T22:54:05.445Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2f/4b/7520114de1ce36bb17cbc98d0fcda048a9f755bedaeb73b92137aeaaf1db/langchain_openai-1.3.3-py3-none-any.whl", hash = "sha256:e469659862c8aabba4f6653df973206e7be54f98cf2275c86be7f06b7abe20d7", size = 120437, upload-time = "2026-06-22T22:54:03.8Z" },
 ]
 
 [[package]]
@@ -1120,6 +1349,31 @@ wheels = [
 ]
 
 [[package]]
+name = "mcp"
+version = "1.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpx" },
+    { name = "httpx-sse" },
+    { name = "jsonschema" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "python-multipart" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "sse-starlette" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+    { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6e/77/9450b8f251a13affb6281997d0523c4615f8a8b35d0b21ff30db3a5aac9d/mcp-1.28.1.tar.gz", hash = "sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683", size = 638501, upload-time = "2026-06-26T12:57:29.093Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e2/5e/d118fce19f87a2e7d8101c35c8ae0ec289098a4df0ff244cec23e415aca0/mcp-1.28.1-py3-none-any.whl", hash = "sha256:2726bca5e7193f61c5dde8b12500a6de2d9acf6d1a1c0be9e8c2e706437991df", size = 222620, upload-time = "2026-06-26T12:57:27.218Z" },
+]
+
+[[package]]
 name = "mdurl"
 version = "0.1.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1135,15 +1389,18 @@ source = { virtual = "." }
 dependencies = [
     { name = "fastapi" },
     { name = "langchain" },
+    { name = "langchain-anthropic" },
     { name = "langchain-community" },
     { name = "langchain-core" },
     { name = "langchain-groq" },
     { name = "langchain-huggingface" },
+    { name = "langchain-openai" },
     { name = "langchain-postgres" },
     { name = "langchain-text-splitters" },
     { name = "langdetect" },
     { name = "langsmith" },
     { name = "markdownify" },
+    { name = "mcp" },
     { name = "psycopg", extra = ["binary"] },
     { name = "pydantic" },
     { name = "python-dotenv" },
@@ -1158,15 +1415,18 @@ dependencies = [
 requires-dist = [
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "langchain", specifier = ">=1.2.15" },
+    { name = "langchain-anthropic", specifier = ">=0.3" },
     { name = "langchain-community", specifier = ">=0.4.1" },
     { name = "langchain-core", specifier = ">=1.3.0" },
     { name = "langchain-groq", specifier = ">=1.1.2" },
     { name = "langchain-huggingface", specifier = ">=1.2.2" },
+    { name = "langchain-openai", specifier = ">=0.3" },
     { name = "langchain-postgres", specifier = ">=0.0.17" },
     { name = "langchain-text-splitters", specifier = ">=1.1.2" },
     { name = "langdetect", specifier = ">=1.0.9" },
     { name = "langsmith", specifier = ">=0.3.0" },
     { name = "markdownify", specifier = ">=1.2.2" },
+    { name = "mcp", specifier = ">=1.0" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.1.0" },
     { name = "pydantic", specifier = ">=2.13.3" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
@@ -1340,7 +1600,7 @@ name = "nvidia-cublas"
 version = "13.1.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cuda-nvrtc" },
+    { name = "nvidia-cuda-nvrtc", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/a1/0bd24ee8c8d03adac032fd2909426a00c88f8c57961b1277ded97f91119f/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b7a210458267ac818974c53038fbec2e969d5c99f305ab15c72522fa9f001dd5", size = 542848918, upload-time = "2026-04-08T18:46:22.985Z" },
@@ -1379,7 +1639,7 @@ name = "nvidia-cudnn-cu13"
 version = "9.20.0.48"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
+    { name = "nvidia-cublas", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/c5/83384d846b2fd17c44bd499b36c75a45ed4f095fbbb2252294e89cea5c5c/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:e31454ae00094b0c55319d9d15b6fa2fc50a9e1c0f5c8c80fb75258234e731e1", size = 444574296, upload-time = "2026-03-09T19:28:27.751Z" },
@@ -1391,7 +1651,7 @@ name = "nvidia-cufft"
 version = "12.0.0.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
@@ -1421,9 +1681,9 @@ name = "nvidia-cusolver"
 version = "12.0.4.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
-    { name = "nvidia-cusparse" },
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-cublas", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-cusparse", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
@@ -1435,7 +1695,7 @@ name = "nvidia-cusparse"
 version = "12.6.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
@@ -1485,6 +1745,25 @@ source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/f3/d86c845465a2723ad7e1e5c36dcd75ddb82898b3f53be47ebd429fb2fa5d/nvidia_nvtx-13.0.85-py3-none-manylinux1_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:4936d1d6780fbe68db454f5e72a42ff64d1fd6397df9f363ae786930fd5c1cd4", size = 148047, upload-time = "2025-09-04T08:29:01.761Z" },
     { url = "https://files.pythonhosted.org/packages/a8/64/3708a90d1ebe202ffdeb7185f878a3c84d15c2b2c31858da2ce0583e2def/nvidia_nvtx-13.0.85-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cb7780edb6b14107373c835bf8b72e7a178bac7367e23da7acb108f973f157a6", size = 148878, upload-time = "2025-09-04T08:28:53.627Z" },
+]
+
+[[package]]
+name = "openai"
+version = "2.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/49/f5/7c7cb955305cb41f7f3c5fd7e0e38bf6bbf2658468863d4b7b868a5cb8df/openai-2.44.0.tar.gz", hash = "sha256:68a5a5ffad82b8ff7d451c437529fb64f7c3b8123aaf0c021966a882d9e3947d", size = 988753, upload-time = "2026-06-24T20:56:02.293Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/f4/561ed79fd94876160018a5e75254cfcb9b0e62d4dded9dcb20072e86d623/openai-2.44.0-py3-none-any.whl", hash = "sha256:0a2a3ab2e29aeda368700f662ff9ba0f9df17ba4c54577a64e08b8115a3cc0ad", size = 1366216, upload-time = "2026-06-24T20:55:58.882Z" },
 ]
 
 [[package]]
@@ -1865,6 +2144,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
 name = "pydantic"
 version = "2.13.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1972,6 +2260,20 @@ wheels = [
 ]
 
 [[package]]
+name = "pyjwt"
+version = "2.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -1999,6 +2301,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5b/42/55c32bb9b12693c092ad250a0e82edb5b31ddeda6eb772de5f308b3804ad/python_multipart-0.0.32.tar.gz", hash = "sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e", size = 46881, upload-time = "2026-06-04T16:18:58.647Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl", hash = "sha256:ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23", size = 30042, upload-time = "2026-06-04T16:18:57.319Z" },
+]
+
+[[package]]
+name = "pywin32"
+version = "312"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2d/41/12fbfd7f36ed2146d8bc9de96c2741296bf0d490b98508496cff322e274c/pywin32-312-cp313-cp313-win32.whl", hash = "sha256:7a27df850933d16a8eabfbaeb73d52b273e2da667f80d70b01a89d1f6828d02c", size = 6370184, upload-time = "2026-06-04T07:49:36.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/db/36a78e3403099d31d9746d13fdcde5accc43c1155f375a34d15983a479a7/pywin32-312-cp313-cp313-win_amd64.whl", hash = "sha256:c53e878d15a1c44788082bfe712a905433473aa38f86375b7cf8b45e3acbaaf9", size = 6914298, upload-time = "2026-06-04T07:49:38.876Z" },
+    { url = "https://files.pythonhosted.org/packages/84/37/c1697194092b76de9ed47ca124323f02c57ffc8a45c06f88a3d5acaf01eb/pywin32-312-cp313-cp313-win_arm64.whl", hash = "sha256:59aba5d5940842075343a5ddc6b11f1cdf0d1567fe745290359dfbcc7c2eb831", size = 6727640, upload-time = "2026-06-04T07:49:41.083Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/2b/1f3cded5822fd49c02f40544cbb5f58c7cfd6b1694869fd476cb6170ee97/pywin32-312-cp314-cp314-win32.whl", hash = "sha256:a77a90fbb6881238d2ca9c6fd797b25817f3768fe78d214a90137ff055a75f5b", size = 6468928, upload-time = "2026-06-04T07:49:43.188Z" },
+    { url = "https://files.pythonhosted.org/packages/21/82/3bf86d2e2808902013132e1ce905a7da0da53790f3836c64bf44d55e24f3/pywin32-312-cp314-cp314-win_amd64.whl", hash = "sha256:a4dd3a848290ef724347b19f301045831d8e802fa4464f491b98b1e0a081432e", size = 7024157, upload-time = "2026-06-04T07:49:45.34Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/0e/73f6d6800b4f27655abd9e9f6aaeaefcddb2b946e4674efa2bab184a7f7b/pywin32-312-cp314-cp314-win_arm64.whl", hash = "sha256:9fce94568364e0155e6dfb781ac5d95903be8baf28670632beab1b523f300daa", size = 6839598, upload-time = "2026-06-04T07:49:47.613Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/61/caa39686032d2ebdd04ff0ab5cbe163126c0066d98e00c9018646e42393b/pywin32-312-cp315-cp315-win32.whl", hash = "sha256:5c1fbe4a937a73ae9297384a3da38518cbc694c68ad8a809b2e19acd350f03ed", size = 6471159, upload-time = "2026-06-04T07:49:50.035Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/cd/7e1de64a4a6f69c04214169657ccab0d93a670ea50e35eb8f489d7378249/pywin32-312-cp315-cp315-win_amd64.whl", hash = "sha256:c2f03a0f73f804a13c2735b99392b0cd426bb4f2c4d0178e5ac966a0f21618d5", size = 7025293, upload-time = "2026-06-04T07:49:54.857Z" },
+    { url = "https://files.pythonhosted.org/packages/23/ed/4532e9388e65fa16b46776ef47ad631a64eda1631884488af707666350ed/pywin32-312-cp315-cp315-win_arm64.whl", hash = "sha256:a8597d28f267b39074aef51fa593530082b39cbe5a074226096857b1fed2dfb9", size = 6840337, upload-time = "2026-06-04T07:49:57.531Z" },
 ]
 
 [[package]]
@@ -2478,6 +2796,19 @@ asyncio = [
 ]
 
 [[package]]
+name = "sse-starlette"
+version = "3.4.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "starlette" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d2/1b/bc9e3e7a72dcdad7dc7888758f5d00f56f8909ed5cfdff822bd72bb4c520/sse_starlette-3.4.5.tar.gz", hash = "sha256:83072538bc211a2f68b7b0422226c4af3e9b62e106e07034664b832ca019842a", size = 35249, upload-time = "2026-06-20T17:36:58.322Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/75/c88d3f5dafd59c791da1ce27650d30bf5b70cbf1cbf01cd00e5f9e360915/sse_starlette-3.4.5-py3-none-any.whl", hash = "sha256:e71bad53323f65573c3864a6c3bd0c1eb6e5f092b2e48082b0c35927d19ca296", size = 16518, upload-time = "2026-06-20T17:36:56.729Z" },
+]
+
+[[package]]
 name = "starlette"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2552,6 +2883,46 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b7/4d/08c89e34946fce2aec4fbb45c9016efd5f4d7f24af8e5d93296e935631d8/threadpoolctl-3.6.0.tar.gz", hash = "sha256:8ab8b4aa3491d812b623328249fab5302a68d2d71745c8a4c719a2fcaba9f44e", size = 21274, upload-time = "2025-03-13T13:49:23.031Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl", hash = "sha256:43a0b8fd5a2928500110039e43a5eed8480b918967083ea48dc3ab9f13c4a7fb", size = 18638, upload-time = "2025-03-13T13:49:21.846Z" },
+]
+
+[[package]]
+name = "tiktoken"
+version = "0.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "regex" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/e5/5f3cb2159769d0f4324c0e9e87f9de3c4b1cd45848a96b2eb3566ad5ca77/tiktoken-0.13.0.tar.gz", hash = "sha256:c9435714c3a84c2319499de9a300c0e604449dd0799ff246458b3bb6a7f433c1", size = 38986, upload-time = "2026-05-15T04:51:27.153Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/83/b096c859c2a47c11731bf2f5885f4028b809dfe2396582883eed9cae372f/tiktoken-0.13.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5df5d1507bd245f1ccad4a074698240021239e455eb0bb4ced4e3d7181872154", size = 1034228, upload-time = "2026-05-15T04:50:40.988Z" },
+    { url = "https://files.pythonhosted.org/packages/53/61/c68e123b6d753e3fc2751e9b18e732c9d8bf1e1926762e736eee935d931c/tiktoken-0.13.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8fe806a50664e83a6ffd56cbd1e4f5dcc6cd32a3e7538f70dc38b1a271384545", size = 982978, upload-time = "2026-05-15T04:50:42.195Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/8b/96cc178cc584e65d363134500f297790b06cd48cdeb1e8fcf7bbe60f4715/tiktoken-0.13.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:125bc05005e747f993a83dc67934249932d6e4209854452cd4c0b1d53fba3ba2", size = 1116355, upload-time = "2026-05-15T04:50:43.564Z" },
+    { url = "https://files.pythonhosted.org/packages/86/f5/bab735d2c72ea55404b295d02d092644eb5f7cc6205e34d35eb9abfb9ab2/tiktoken-0.13.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:5e6358911cab4adee6712da27d65573496a4f68cf8a2b5fca6a4ad10fc5748cf", size = 1135772, upload-time = "2026-05-15T04:50:44.782Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/b9/6de04ebdf904edfaad87788011b3735087a0c9ea671b9027e1e4e965e8c8/tiktoken-0.13.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:975cbd78d085d75d26b59660e262736dcaed1e35f8f142cd6291025c01d25486", size = 1182415, upload-time = "2026-05-15T04:50:46.422Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/9c/470a05f3b1caf038f44880e334d47ab674e0c80d514c66b375d14d5afa10/tiktoken-0.13.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:75ab9bc99fa020a4c283424590ecd7f3afd70c1c281cb3fa3192a6c3af9f9615", size = 1239879, upload-time = "2026-05-15T04:50:48.052Z" },
+    { url = "https://files.pythonhosted.org/packages/42/a6/c1936d16055436cb32e6c6128d68629622e00f4768562f55653752d34768/tiktoken-0.13.0-cp313-cp313-win_amd64.whl", hash = "sha256:6b1615f0ff71953d19729ceb18865429c185b0a23c5353f1bbca34a394bf60f7", size = 874829, upload-time = "2026-05-15T04:50:49.202Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/07/acb5992c3772b5a36284f742cfb7a5895aa4471d1848ac31464ad50d7fdf/tiktoken-0.13.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:6eb4a5bfbc6426938026b1a334e898ac53541360d62d8c689870160cc80abd67", size = 1033600, upload-time = "2026-05-15T04:50:50.4Z" },
+    { url = "https://files.pythonhosted.org/packages/14/e9/742e9aec30f59b9f161f7ff7cd072e02ea836c9e1c0854a8076dfcd40d5c/tiktoken-0.13.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:43cee3e5400573b2046fbf092cc7a5bc30164f9e4c95ce20714da929df48737a", size = 982516, upload-time = "2026-05-15T04:50:52.03Z" },
+    { url = "https://files.pythonhosted.org/packages/72/74/ca1541b053e7648254d2e4b42a253e1bb4359f2c91a0a8d49228c794e1a0/tiktoken-0.13.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:7de52e3f566d19b3b11bd37eea552c6c305ad74081f736882bd44d148ed4c48d", size = 1115518, upload-time = "2026-05-15T04:50:53.543Z" },
+    { url = "https://files.pythonhosted.org/packages/46/e3/93825eaf5a4a504795b787e5d5dea07fbeb3dabf97aa7b450be8bde59c89/tiktoken-0.13.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:51384448aa508e4df84c0f7c1dc3211c7f7b8096325660ee5fc82f3e11b381ce", size = 1136867, upload-time = "2026-05-15T04:50:55.191Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/46/002b68de6827091d5ae90b048f326e8aad8d953520950e5ce1508879414f/tiktoken-0.13.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:e28157350f7ebf35008dd8e9e0fdb621f976e4230c881099c85e8cf07eaa50e2", size = 1181826, upload-time = "2026-05-15T04:50:56.296Z" },
+    { url = "https://files.pythonhosted.org/packages/db/c6/d393e3185a276505182f7abd93fe714f3c444a2be9180798fa052347504e/tiktoken-0.13.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:165cf1820ea4a354985c2490a5205d4cc74661c934aca79dd0368232fff94e0f", size = 1239489, upload-time = "2026-05-15T04:50:57.918Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/4d/bc07d1f1635d4897a202acc0ae11c2886eaa7325c359ba4741b47bf8e225/tiktoken-0.13.0-cp313-cp313t-win_amd64.whl", hash = "sha256:6c43a675ca14f6f2749ba7f12075d37456015a24b859f2517b9beb4ef30807ec", size = 873820, upload-time = "2026-05-15T04:50:59.528Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/93/0dd6adca026a616c3a92974566b43381eea4b475ce1f36c062b8271a9ac5/tiktoken-0.13.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaaaef47c2406277181d2086484c317bf7fc433e2d5d03ff94f56b0dcec87471", size = 1034977, upload-time = "2026-05-15T04:51:00.957Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/77/5ec6e6bc5b30bed6d93f7f2162d8f6b32437b3ba27cb527cfe004f6109c9/tiktoken-0.13.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ca8b310bd93b3772cb1b7922d915446864860f562bdfe4825c63a0aed3fb28cd", size = 983635, upload-time = "2026-05-15T04:51:02.629Z" },
+    { url = "https://files.pythonhosted.org/packages/94/b0/c8ae9aff00d625c50659b4513e707a0462c4bf5d4d6cc1b802103225c02e/tiktoken-0.13.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:32e0c12305105002c047b3bb1070b0dd9a73b0cb3b2856a8972b810e7a4f5881", size = 1116036, upload-time = "2026-05-15T04:51:04.082Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/ac/6a5dddd1d0a6018ecb389bd0353e6b4a515eb4d2286611bd0ace1937b9e1/tiktoken-0.13.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:5ba5fd62507a932d1241346179e3b39bc7bf7408f03c272652d93b3bedf5db24", size = 1135544, upload-time = "2026-05-15T04:51:05.229Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/b8/585032b4384b2f7dcdaddcb52865c83a701a420d09e3c2b4a2be1c450c57/tiktoken-0.13.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d108bc2d470fc53c8ecd24f2c0fd2b5f98c33e87cdb6aa2e9b8c5dced703d273", size = 1182217, upload-time = "2026-05-15T04:51:06.517Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/b6/993ff1ded3958215fd341a847b8e5ffeb5de473f435296870d314fc91ac4/tiktoken-0.13.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:cb99cb5127449f58d0a2d5f5ccfb390d8dbdfd919c221246caaee29d8725ed51", size = 1239404, upload-time = "2026-05-15T04:51:07.843Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3d/fef7e06e3b33e7538db0ced734cf9fe23b6832d2ac4990c119c377aec55e/tiktoken-0.13.0-cp314-cp314-win_amd64.whl", hash = "sha256:115c4f26ffa11caac8b54eea35c2ad38c612c20a48d35dd15d70a02ac6f51f58", size = 918686, upload-time = "2026-05-15T04:51:08.925Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/82/a7fc44582bc32ab00de988a2299bf77c077f59068b233109e34b7d6ca7e6/tiktoken-0.13.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:472527e9132952f2fbf77cd290658bacf003d4d5a3fabc18e5fbd407cbae4d9b", size = 1034454, upload-time = "2026-05-15T04:51:10.035Z" },
+    { url = "https://files.pythonhosted.org/packages/37/d0/24d8a890c14f432a05cea669c17bebeaa99f96a7c79523b590f564246411/tiktoken-0.13.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:4e2f67d27c9626cdd25fe33d9313c5cdb3d8d82da646b68d6eb8e7e9c20e6448", size = 982976, upload-time = "2026-05-15T04:51:11.23Z" },
+    { url = "https://files.pythonhosted.org/packages/49/b7/2ab43f62788a9266187a9bfc1d3af99ad83e5eaa25fbef168a69cd5ad14f/tiktoken-0.13.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:2b920b35805cd64585a37c3dc7ce65fba4d2d36016be01e1d7942482ca29093a", size = 1115526, upload-time = "2026-05-15T04:51:12.608Z" },
+    { url = "https://files.pythonhosted.org/packages/64/39/1494321ed323ce7a14d88e3cd6cb9058625977df1c6961ddc492bd10a9f3/tiktoken-0.13.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:493af3aa28a4aaf2e3d2600a2ee717252c9bf5ab38fff94eb5a02db5ab77e5ad", size = 1136466, upload-time = "2026-05-15T04:51:13.926Z" },
+    { url = "https://files.pythonhosted.org/packages/96/d9/dfd086aa2d918c563a140720e0ce296cada1634efd2783d5cf51e05f984e/tiktoken-0.13.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:6644c9c2b5cf3916f5a3641d7d12fdb3f006a7b3d9ff6acdaec44e29ab1ff91e", size = 1181863, upload-time = "2026-05-15T04:51:15.025Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/68/a18b4f307086954fdae32714cb4f85562e34f9d34ab206e61f1816aa6018/tiktoken-0.13.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5cb65b60b9408563676d874a3a4ee573370066f0dc4e29d84e82e989c6517424", size = 1239218, upload-time = "2026-05-15T04:51:16.103Z" },
+    { url = "https://files.pythonhosted.org/packages/16/5b/f2aa703a4fc5d2dff73460a7d46cc2f3f44aa0f3dd8eeb20d2a0ecf68862/tiktoken-0.13.0-cp314-cp314t-win_amd64.whl", hash = "sha256:85b78cc3a2c3d48723ca751fa981f1fedccd54194ca0471b957364353a898b07", size = 918110, upload-time = "2026-05-15T04:51:17.237Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
RAG Answer Quality Improvements + Claude Desktop Integration

1. Error Code Handling — retrieval/retriever.py
SQL exact-match retrieval: When a query contains a MOSIP error code (e.g. IDA-MLC-009), the retriever now runs a SQL ILIKE search against langchain_pg_embedding to guarantee the defining constant is always retrieved — not just the closest vector.

Sibling co-retrieval: Fetches all chunks from the same source file (e.g. all constants in IdAuthenticationErrorConstants.java) so the LLM can compare adjacent codes like IDA-MLC-008 vs IDA-MLC-009.

Format specifier annotation: Chunks containing Java format specifiers (%s, %d) are annotated inline with a ⚠️ RUNTIME PLACEHOLDER warning, preventing the LLM from substituting a specific value (e.g. replacing %s with "id" in error messages).

Production vs demo separation: Retrieved code chunks are partitioned into production vs demo/test/mock/sample packages. Demo packages are ranked last so the LLM cites real service implementations, not SampleSDK or DemoService.

MAX_CONTEXT_DOCS=40 hard cap: Added to config/settings.py to prevent context window overflow when exact-match + sibling + vector results stack up.

2. Query Classification & System Prompts — chain/query_engine.py
Environment-debug query class (is_env_debug): New regex detects queries about "works locally but fails in Synergy/hosted/production". These get a dedicated answer format: confirms the local/remote gap, lists env differences to investigate (version mismatch, credentials, network, config drift), cites community threads, and explicitly states HTTP 401/500 in this context are not MOSIP error codes.

is_env_debug + is_error_query can both fire simultaneously: Previously is_env_debug suppressed error code detection. Fixed — env-debug format takes priority but error code rules are appended when both match.

Error code system prompt: Instructs the LLM to state %s/%d are runtime placeholders; never substitute; tell the user to read their actual error response.

Code query system prompt: Added CRITICAL rule — if a class is in a *.demo.*, *.test.*, *.sample.*, or *.mock.* package, flag it as a demo/test implementation, not production.

Community thread citation rule: LLM must state if a community thread has no accepted answer rather than presenting unverified replies as confirmed solutions.

Detection fix: is_env_debug now checks both the original question and the condensed standalone — the LLM condenser was stripping environment signals from long community posts.

Module docstring fix: Updated stale "ChromaDB" reference to "pgvector".

3. Claude Desktop / MCP Server — mcp_server/server.py
New FastMCP server (port 8002, SSE transport): Exposes two tools to Claude Desktop — search_mosip(query) and list_knowledge_sources().

BYOK architecture: Claude Desktop users search the knowledge base using their own Claude subscription — zero LLM cost to the app owner for MCP-routed queries.

Source transparency rules: MCP instructions explicitly forbid silently blending Nexus results with web search or training data. If a specific fact is not in Nexus, the LLM must say so before supplementing.

Error code rules in MCP: Same %s/sibling comparison rules applied to Claude Desktop context.

Live collection counts: list_knowledge_sources() queries get_collection_counts() from the retriever in real time instead of returning hardcoded numbers.

Source URL format: Changed from plain Source: <url> to 📎 <url> for cleaner Claude Desktop rendering.

4. Table-to-Prose Crawler Improvement — crawler/utils.py, crawler/docs_crawler.py, crawler/confluence_crawler.py
New shared utility crawler/utils.py: Contains table_to_prose(table_tag) — converts HTML <table> elements to labelled prose sentences ("vCPU: 12, RAM: 32 GB, Disk: 128 GB.") before embedding.

Why: markdownify converts tables to pipe-tables (| 32 GB |) whose cells carry no semantic meaning without headers. Hardware/config tables were not matching queries like "minimum RAM requirement". Prose format retrieves correctly.

Applied to: docs_crawler.py (MOSIP docs sitemap) and confluence_crawler.py (Confluence pages) — both now pre-process all <table> elements before calling markdownify.

DRY fix: Removed duplicated inline _table_to_prose() from both crawlers; both now import from crawler/utils.py.

5. Settings Page & BYOK UI — app/pages/settings.py, app/app.py, api/main.py
New Settings page: Dedicated Streamlit page for LLM provider selection (Groq / Anthropic / OpenAI), API key input (password field, session-only, never stored server-side), and optional model override.

BYOK flow: User API key travels in ChatRequest body → ask() → build_llm() factory; never logged or persisted.

Dynamic footer: App footer shows the active LLM provider instead of hardcoded "Groq Llama 3.3".

6. Documentation Updates
README.md: Added BYOK, MCP/Claude Desktop, query intelligence, hybrid retrieval, and production/demo separation to Features and Tech Stack tables. Added "Claude Desktop / MCP Integration" setup section with step-by-step config and MCP tools table. Updated project structure for mcp_server/, app/pages/settings.py, crawler/utils.py.

docs/MOSIP_Nexus_Rancher_Deployment_Guide.md: Updated Section 1 to list nexus-mcp as the fourth runtime component. Added nexus-mcp row to the compute footprint table (0.25 cores, ~2.5 GB RAM, port 8002); updated steady-state totals.

Markdown linting: Fixed all |---| → | --- | table separators and added language specifiers to fenced code blocks in both files.

Files changed: retrieval/retriever.py, chain/query_engine.py, config/settings.py, mcp_server/server.py (new), crawler/utils.py (new), crawler/docs_crawler.py, crawler/confluence_crawler.py, app/app.py, app/pages/settings.py (new), api/main.py, README.md, docs/MOSIP_Nexus_Rancher_Deployment_Guide.md