### PR TITLE
MOSIP-45245: GitHub Tracker user details, roles, and role-filtered APIs

### DIFF
--- a/github-activity-tracker/.env.example
+++ b/github-activity-tracker/.env.example
@@ -10,6 +10,10 @@ RDS_DATABASE=github_tracker
 RDS_USER=postgres
 RDS_PASSWORD=your-password
 
+# Single source of truth for lookup tables (seeded into DB on migrate/start).
+GITHUB_ORG=mosip,inji
+USER_ROLES=Developer,Tech Lead,Architect,Product Owner,Leadership,QA Engineer,DevOps Engineer
+
 # Variables used by the Postgres container itself:
 # POSTGRES_DB=github_data
 # POSTGRES_USER=github_user

--- a/github-activity-tracker/backend/.env.example
+++ b/github-activity-tracker/backend/.env.example
@@ -4,3 +4,11 @@ RDS_DATABASE=github_data
 RDS_USER=your-rds-user
 RDS_PASSWORD=your-rds-password
 GITHUB_TOKEN=your-github-token
+
+# Read from .env on backend start and stored in user_roles / organizations tables.
+GITHUB_ORG=mosip,inji
+USER_ROLES=Developer,Tech Lead,Architect,Product Owner,Leadership,QA Engineer,DevOps Engineer
+
+# Bearer token required to call /admin/* endpoints (sync + role management).
+# Generate a strong random value, e.g. `openssl rand -hex 32`.
+ADMIN_API_TOKEN=your-admin-api-token

--- a/github-activity-tracker/backend/app.js
+++ b/github-activity-tracker/backend/app.js
@@ -16,6 +16,8 @@ const orgActivityRoute = require('./routes/orgActivityRoute');
 const orgSummaryRoute = require('./routes/orgSummaryRoute');
 const orgUsersRoute = require('./routes/orgUsersRoute');
 const userDetailsRoute = require('./routes/userDetailsRoute');
+const userNameSyncRoute = require('./routes/userNameSyncRoute');
+const userRoleRoute = require('./routes/userRoleRoute');
 
 const app = express();
 const PORT = process.env.PORT || 3000;
@@ -34,6 +36,9 @@ app.get('/', (req, res) => {
       'POST /admin/sync/commits': 'Sync commits for all repositories in DB',
       'POST /admin/sync/prs': 'Sync PRs for all repositories in DB',
       'POST /admin/sync/reviews': 'Sync PR reviews for all repositories in DB',
+      'POST /admin/sync/user-names': 'Backfill GitHub profile names for users in DB',
+      'POST /admin/users/role': 'Assign job role to a GitHub user',
+      'GET /admin/users/:login/role': 'Fetch job role for a GitHub user',
     },
   });
 });
@@ -43,6 +48,8 @@ app.use(repoSyncRoute);
 app.use(commitSyncRoute);
 app.use(prSyncRoute);
 app.use(reviewSyncRoute);
+app.use(userNameSyncRoute);
+app.use(userRoleRoute);
 app.use(orgUsersRoute);
 app.use(orgSummaryRoute);
 app.use(userDetailsRoute);

--- a/github-activity-tracker/backend/app.js
+++ b/github-activity-tracker/backend/app.js
@@ -2,7 +2,7 @@
  * GitHub Activity Tracker – Backend API
  *
  * Express server that exposes admin sync endpoints to pull repository, commit,
- * PR, and review data from GitHub into PostgreSQL. Run migrations first (npm run migrate).
+ * PR, and review data from GitHub into PostgreSQL.
  */
 require('dotenv').config();
 const express = require('express');
@@ -18,6 +18,9 @@ const orgUsersRoute = require('./routes/orgUsersRoute');
 const userDetailsRoute = require('./routes/userDetailsRoute');
 const userNameSyncRoute = require('./routes/userNameSyncRoute');
 const userRoleRoute = require('./routes/userRoleRoute');
+const userRolesRoute = require('./routes/userRolesRoute');
+const organizationsRoute = require('./routes/organizationsRoute');
+const { ensureLookupTables } = require('./db/initLookupTables');
 
 const app = express();
 const PORT = process.env.PORT || 3000;
@@ -37,8 +40,10 @@ app.get('/', (req, res) => {
       'POST /admin/sync/prs': 'Sync PRs for all repositories in DB',
       'POST /admin/sync/reviews': 'Sync PR reviews for all repositories in DB',
       'POST /admin/sync/user-names': 'Backfill GitHub profile names for users in DB',
-      'POST /admin/users/role': 'Assign job role to a GitHub user',
+      'POST /admin/users/role': 'Assign or change job role for a GitHub user',
       'GET /admin/users/:login/role': 'Fetch job role for a GitHub user',
+      'GET /user-roles': 'List assignable user job roles',
+      'GET /organizations': 'List tracked GitHub organizations',
     },
   });
 });
@@ -50,12 +55,31 @@ app.use(prSyncRoute);
 app.use(reviewSyncRoute);
 app.use(userNameSyncRoute);
 app.use(userRoleRoute);
+app.use(userRolesRoute);
+app.use(organizationsRoute);
 app.use(orgUsersRoute);
 app.use(orgSummaryRoute);
 app.use(userDetailsRoute);
 app.use(orgActivityRoute);
 app.use(leaderboardRoute);
 
-app.listen(PORT, () => {
+app.listen(PORT, async () => {
+  try {
+    const result = await ensureLookupTables();
+
+    if (result.createdTables.length > 0) {
+      console.log(`Created tables: ${result.createdTables.join(', ')}`);
+    }
+
+    if (result.rolesAdded > 0 || result.orgsAdded > 0) {
+      console.log(`Added from .env: ${result.rolesAdded} role(s), ${result.orgsAdded} organization(s)`);
+    } else if (result.createdTables.length === 0) {
+      console.log('Lookup tables already exist; no new roles or organizations to add.');
+    }
+  } catch (error) {
+    console.error('Failed to initialize lookup tables:', error.message);
+    process.exit(1);
+  }
+
   console.log(`Server running on http://localhost:${PORT}`);
 });

--- a/github-activity-tracker/backend/config/defaultUserRoles.js
+++ b/github-activity-tracker/backend/config/defaultUserRoles.js
@@ -1,0 +1,16 @@
+function parseUserRolesFromEnv() {
+  const fromEnv = process.env.USER_ROLES;
+
+  if (!fromEnv || !fromEnv.trim()) {
+    return [];
+  }
+
+  return fromEnv
+    .split(',')
+    .map((role) => role.trim())
+    .filter(Boolean);
+}
+
+module.exports = {
+  parseUserRolesFromEnv,
+};

--- a/github-activity-tracker/backend/config/organizations.js
+++ b/github-activity-tracker/backend/config/organizations.js
@@ -1,0 +1,15 @@
+const {
+  getAllOrganizations,
+  getOrganizationSlugs,
+  getOrganizationNames,
+  normalizeOrganization,
+  isValidOrganization,
+} = require('../services/organizationsService');
+
+module.exports = {
+  getAllOrganizations,
+  getOrganizationSlugs,
+  getOrganizationNames,
+  normalizeOrganization,
+  isValidOrganization,
+};

--- a/github-activity-tracker/backend/config/syncConfig.js
+++ b/github-activity-tracker/backend/config/syncConfig.js
@@ -5,6 +5,18 @@
 /** Delay in ms between processing each repo when syncing commits/PRs/reviews for all repos. */
 const DELAY_BETWEEN_REPOS_MS = 300;
 
+/** Default batch size for backfilling missing GitHub user display names per request. */
+const NAME_BACKFILL_BATCH_SIZE = 50;
+
+/** Delay in ms between GitHub profile lookups when backfilling user names. */
+const NAME_FETCH_DELAY_MS = 120;
+
+/** Maximum batch size allowed for a single user-name backfill request. */
+const NAME_BACKFILL_MAX_BATCH_SIZE = 500;
+
 module.exports = {
   DELAY_BETWEEN_REPOS_MS,
+  NAME_BACKFILL_BATCH_SIZE,
+  NAME_FETCH_DELAY_MS,
+  NAME_BACKFILL_MAX_BATCH_SIZE,
 };

--- a/github-activity-tracker/backend/config/userRoles.js
+++ b/github-activity-tracker/backend/config/userRoles.js
@@ -1,0 +1,18 @@
+const USER_ROLES = [
+  'Developer',
+  'Tech Lead',
+  'Architect',
+  'Product Owner',
+  'Leadership',
+  'QA Engineer',
+  'DevOps Engineer',
+];
+
+function isValidUserRole(role) {
+  return USER_ROLES.includes(role);
+}
+
+module.exports = {
+  USER_ROLES,
+  isValidUserRole,
+};

--- a/github-activity-tracker/backend/config/userRoles.js
+++ b/github-activity-tracker/backend/config/userRoles.js
@@ -1,18 +1,11 @@
-const USER_ROLES = [
-  'Developer',
-  'Tech Lead',
-  'Architect',
-  'Product Owner',
-  'Leadership',
-  'QA Engineer',
-  'DevOps Engineer',
-];
-
-function isValidUserRole(role) {
-  return USER_ROLES.includes(role);
-}
+const {
+  getAllUserRoles,
+  getUserRoleNames,
+  isValidUserRole,
+} = require('../services/userRolesService');
 
 module.exports = {
-  USER_ROLES,
+  getAllUserRoles,
+  getUserRoleNames,
   isValidUserRole,
 };

--- a/github-activity-tracker/backend/db/initLookupTables.js
+++ b/github-activity-tracker/backend/db/initLookupTables.js
@@ -1,0 +1,96 @@
+const pool = require('./dbPool');
+const { parseUserRolesFromEnv } = require('../config/defaultUserRoles');
+
+function parseOrganizationsFromEnv(value = process.env.GITHUB_ORG) {
+  return (value || '')
+    .split(',')
+    .map((slug) => slug.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+async function tableExists(tableName) {
+  const result = await pool.query(
+    `
+      SELECT 1
+      FROM information_schema.tables
+      WHERE table_schema = 'public' AND table_name = $1
+      LIMIT 1
+    `,
+    [tableName]
+  );
+  return result.rowCount > 0;
+}
+
+async function ensureLookupTables() {
+  const roles = parseUserRolesFromEnv();
+  const orgs = parseOrganizationsFromEnv();
+  const createdTables = [];
+
+  if (!(await tableExists('user_roles'))) {
+    await pool.query(`
+      CREATE TABLE user_roles (
+        id SERIAL PRIMARY KEY,
+        name VARCHAR(50) NOT NULL UNIQUE,
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+      )
+    `);
+    createdTables.push('user_roles');
+  }
+
+  if (!(await tableExists('organizations'))) {
+    await pool.query(`
+      CREATE TABLE organizations (
+        id SERIAL PRIMARY KEY,
+        slug VARCHAR(255) NOT NULL UNIQUE,
+        name VARCHAR(255) NOT NULL,
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+      )
+    `);
+    createdTables.push('organizations');
+  }
+
+  let rolesAdded = 0;
+  for (const name of roles) {
+    const result = await pool.query(
+      `
+        INSERT INTO user_roles (name)
+        VALUES ($1)
+        ON CONFLICT (name) DO NOTHING
+        RETURNING id
+      `,
+      [name]
+    );
+    if (result.rowCount > 0) {
+      rolesAdded += 1;
+    }
+  }
+
+  let orgsAdded = 0;
+  for (const slug of orgs) {
+    const result = await pool.query(
+      `
+        INSERT INTO organizations (slug, name)
+        VALUES ($1, $2)
+        ON CONFLICT (slug) DO NOTHING
+        RETURNING id
+      `,
+      [slug, slug.toUpperCase()]
+    );
+    if (result.rowCount > 0) {
+      orgsAdded += 1;
+    }
+  }
+
+  return {
+    roles,
+    orgs,
+    createdTables,
+    rolesAdded,
+    orgsAdded,
+  };
+}
+
+module.exports = {
+  ensureLookupTables,
+  parseOrganizationsFromEnv,
+};

--- a/github-activity-tracker/backend/migrations/005_add_name_to_github_users.sql
+++ b/github-activity-tracker/backend/migrations/005_add_name_to_github_users.sql
@@ -1,0 +1,3 @@
+-- GitHub profile display name (from GET /users/{login} or GraphQL User.name).
+ALTER TABLE github_users
+  ADD COLUMN IF NOT EXISTS name VARCHAR(255);

--- a/github-activity-tracker/backend/migrations/006_add_role_to_github_users.sql
+++ b/github-activity-tracker/backend/migrations/006_add_role_to_github_users.sql
@@ -1,0 +1,6 @@
+-- Job role for team members (set manually until admin update API exists).
+-- Allowed values: Developer, Tech Lead, Architect, Product Owner, Leadership, QA Engineer, DevOps Engineer
+ALTER TABLE github_users
+  ADD COLUMN IF NOT EXISTS role VARCHAR(50);
+
+CREATE INDEX IF NOT EXISTS idx_github_users_role ON github_users(role);

--- a/github-activity-tracker/backend/migrations/007_create_user_details_table.sql
+++ b/github-activity-tracker/backend/migrations/007_create_user_details_table.sql
@@ -1,0 +1,87 @@
+-- User role/organization assignments with history. One active row per user at a time.
+-- Lookup tables (user_roles, organizations) are created at app startup from .env.
+
+CREATE TABLE IF NOT EXISTS user_details (
+  id SERIAL PRIMARY KEY,
+  user_id INTEGER NOT NULL REFERENCES github_users(id) ON DELETE CASCADE,
+  role_id INTEGER REFERENCES user_roles(id),
+  organization_id INTEGER REFERENCES organizations(id),
+  active BOOLEAN NOT NULL DEFAULT true,
+  active_from TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  active_to TIMESTAMP,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+ALTER TABLE user_details
+  ADD COLUMN IF NOT EXISTS role_id INTEGER REFERENCES user_roles(id),
+  ADD COLUMN IF NOT EXISTS organization_id INTEGER REFERENCES organizations(id);
+
+ALTER TABLE user_details
+  DROP COLUMN IF EXISTS login,
+  DROP COLUMN IF EXISTS name,
+  DROP COLUMN IF EXISTS github_user_id;
+
+CREATE INDEX IF NOT EXISTS idx_user_details_user_id ON user_details(user_id);
+CREATE INDEX IF NOT EXISTS idx_user_details_role_id ON user_details(role_id);
+CREATE INDEX IF NOT EXISTS idx_user_details_organization_id ON user_details(organization_id);
+CREATE INDEX IF NOT EXISTS idx_user_details_active_from ON user_details(active_from);
+CREATE INDEX IF NOT EXISTS idx_user_details_active_to ON user_details(active_to);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_user_details_one_active_per_user
+  ON user_details(user_id)
+  WHERE active = true;
+
+-- GitHub profile name lives on github_users; assignments live in user_details.
+ALTER TABLE github_users
+  ADD COLUMN IF NOT EXISTS name VARCHAR(255);
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'user_details'
+      AND column_name = 'name'
+  ) THEN
+    UPDATE github_users u
+    SET
+      name = ud.name,
+      updated_at = CURRENT_TIMESTAMP
+    FROM user_details ud
+    WHERE ud.user_id = u.id
+      AND ud.active = true
+      AND ud.name IS NOT NULL
+      AND (u.name IS NULL OR u.name = '');
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'github_users'
+      AND column_name = 'role'
+  ) THEN
+    INSERT INTO user_details (user_id, role_id, active, active_from, active_to)
+    SELECT
+      u.id,
+      ur.id,
+      true,
+      COALESCE(u.updated_at, u.inserted_at, CURRENT_TIMESTAMP),
+      NULL
+    FROM github_users u
+    JOIN user_roles ur ON ur.name = u.role
+    WHERE u.role IS NOT NULL
+      AND NOT EXISTS (
+        SELECT 1 FROM user_details ud WHERE ud.user_id = u.id AND ud.active = true
+      );
+  END IF;
+END $$;
+
+DROP INDEX IF EXISTS idx_github_users_role;
+ALTER TABLE github_users
+  DROP COLUMN IF EXISTS role;

--- a/github-activity-tracker/backend/migrations/008_backfill_user_details_active_from.sql
+++ b/github-activity-tracker/backend/migrations/008_backfill_user_details_active_from.sql
@@ -1,0 +1,41 @@
+-- Backdate user_details.active_from so historical activity before user sync
+-- is included when a role is first assigned.
+UPDATE user_details ud
+SET
+  active_from = LEAST(
+    ud.active_from,
+    COALESCE(
+      (SELECT MIN(e.created_at) FROM activity_events e WHERE e.user_id = ud.user_id),
+      ud.active_from
+    )
+  ),
+  updated_at = CURRENT_TIMESTAMP
+WHERE EXISTS (
+  SELECT 1 FROM activity_events e WHERE e.user_id = ud.user_id
+);
+
+-- First role assignment rows should cover all prior activity, not only from assignment time.
+UPDATE user_details current_ud
+SET
+  active_from = LEAST(
+    current_ud.active_from,
+    COALESCE(
+      (SELECT MIN(e.created_at) FROM activity_events e WHERE e.user_id = current_ud.user_id),
+      current_ud.active_from
+    ),
+    COALESCE(
+      (SELECT MIN(h.active_from) FROM user_details h WHERE h.user_id = current_ud.user_id),
+      current_ud.active_from
+    )
+  ),
+  updated_at = CURRENT_TIMESTAMP
+WHERE current_ud.role_id IS NOT NULL
+  AND NOT EXISTS (
+    SELECT 1
+    FROM user_details prior_role
+    WHERE prior_role.user_id = current_ud.user_id
+      AND prior_role.role_id IS NOT NULL
+      AND prior_role.id <> current_ud.id
+      AND prior_role.active_to IS NOT NULL
+      AND prior_role.active_to <= current_ud.active_from
+  );

--- a/github-activity-tracker/backend/migrations/009_user_details_role_organization_ids.sql
+++ b/github-activity-tracker/backend/migrations/009_user_details_role_organization_ids.sql
@@ -1,0 +1,49 @@
+-- Store role/organization assignments as FKs to user_roles and organizations.
+
+ALTER TABLE user_details
+  ADD COLUMN IF NOT EXISTS role_id INTEGER REFERENCES user_roles(id),
+  ADD COLUMN IF NOT EXISTS organization_id INTEGER REFERENCES organizations(id);
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'user_details'
+      AND column_name = 'role'
+  ) THEN
+    UPDATE user_details ud
+    SET role_id = ur.id
+    FROM user_roles ur
+    WHERE ud.role IS NOT NULL
+      AND ur.name = ud.role
+      AND ud.role_id IS NULL;
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'user_details'
+      AND column_name = 'organization'
+  ) THEN
+    UPDATE user_details ud
+    SET organization_id = o.id
+    FROM organizations o
+    WHERE ud.organization IS NOT NULL
+      AND o.slug = LOWER(ud.organization)
+      AND ud.organization_id IS NULL;
+  END IF;
+END $$;
+
+ALTER TABLE user_details
+  DROP COLUMN IF EXISTS role,
+  DROP COLUMN IF EXISTS organization;
+
+DROP INDEX IF EXISTS idx_user_details_role;
+CREATE INDEX IF NOT EXISTS idx_user_details_role_id ON user_details(role_id);
+CREATE INDEX IF NOT EXISTS idx_user_details_organization_id ON user_details(organization_id);

--- a/github-activity-tracker/backend/migrations/runMigrations.js
+++ b/github-activity-tracker/backend/migrations/runMigrations.js
@@ -1,17 +1,27 @@
 /**
- * Run all SQL migrations in order (001_*.sql, 002_*.sql, ...).
- * Use: npm run migrate (from backend directory).
- * Requires RDS_* env vars in .env. Run once per environment (local, staging, prod).
+ * Run SQL migrations in order (001_*.sql, 002_*.sql, ...).
+ * Migrations are idempotent. Run manually: npm run migrate
  */
 require('dotenv').config();
 const fs = require('fs');
 const path = require('path');
 const pool = require('../db/dbPool');
+const { ensureLookupTables } = require('../db/initLookupTables');
 
-async function runMigrations() {
+async function runMigrations({ closePool = true } = {}) {
+  const lookupResult = await ensureLookupTables();
+  if (lookupResult.createdTables.length > 0) {
+    console.log(`Created lookup tables: ${lookupResult.createdTables.join(', ')}`);
+  }
+  if (lookupResult.rolesAdded > 0 || lookupResult.orgsAdded > 0) {
+    console.log(
+      `Seeded from env: ${lookupResult.rolesAdded} role(s), ${lookupResult.orgsAdded} organization(s)`
+    );
+  }
+
   const migrationsDir = path.join(__dirname);
   const files = fs.readdirSync(migrationsDir)
-    .filter(file => file.endsWith('.sql'))
+    .filter((file) => file.endsWith('.sql'))
     .sort();
 
   console.log(`Found ${files.length} migration file(s)`);
@@ -31,10 +41,17 @@ async function runMigrations() {
   }
 
   console.log('All migrations completed successfully!');
-  await pool.end();
+
+  if (closePool) {
+    await pool.end();
+  }
 }
 
-runMigrations().catch(error => {
-  console.error('Migration failed:', error);
-  process.exit(1);
-});
+module.exports = { runMigrations };
+
+if (require.main === module) {
+  runMigrations().catch((error) => {
+    console.error('Migration failed:', error);
+    process.exit(1);
+  });
+}

--- a/github-activity-tracker/backend/routes/leaderBoardRoute.js
+++ b/github-activity-tracker/backend/routes/leaderBoardRoute.js
@@ -14,7 +14,7 @@ router.get("/orgs/:org_id/leaderboard", async (req, res) => {
       return res.status(400).json({ error: "Invalid org_id" });
     }
 
-    if (!["daily", "weekly", "monthly", "all"].includes(period)) {
+    if (!["daily", "weekly", "monthly", "yearly", "all"].includes(period)) {
       return res.status(400).json({ error: "Invalid period value" });
     }
 

--- a/github-activity-tracker/backend/routes/orgActivityRoute.js
+++ b/github-activity-tracker/backend/routes/orgActivityRoute.js
@@ -1,10 +1,11 @@
 const express = require("express");
 const router = express.Router();
 const { getOrgActivity } = require("../services/orgActivityService");
+const { isValidUserRole } = require("../config/userRoles");
 
 router.get("/orgs/:org_id/activity", async (req, res) => {
   const { org_id } = req.params;
-  const { period = "weekly" } = req.query;
+  const { period = "weekly", role } = req.query;
 
   if (!org_id || typeof org_id !== "string") {
     return res.status(400).json({ error: "Invalid org_id" });
@@ -14,8 +15,13 @@ router.get("/orgs/:org_id/activity", async (req, res) => {
     return res.status(400).json({ error: "Invalid period value" });
   }
 
+  if (role && role !== "all" && !isValidUserRole(role)) {
+    return res.status(400).json({ error: "Invalid role value" });
+  }
+
   try {
-    const data = await getOrgActivity(org_id, period);
+    const roleFilter = role && role !== "all" ? role : null;
+    const data = await getOrgActivity(org_id, period, roleFilter);
     return res.json(data);
   } catch (err) {
     console.error("Error fetching org activity:", err);

--- a/github-activity-tracker/backend/routes/orgActivityRoute.js
+++ b/github-activity-tracker/backend/routes/orgActivityRoute.js
@@ -11,11 +11,11 @@ router.get("/orgs/:org_id/activity", async (req, res) => {
     return res.status(400).json({ error: "Invalid org_id" });
   }
 
-  if (!["daily", "weekly", "monthly"].includes(period)) {
+  if (!["daily", "weekly", "monthly", "yearly"].includes(period)) {
     return res.status(400).json({ error: "Invalid period value" });
   }
 
-  if (role && role !== "all" && !isValidUserRole(role)) {
+  if (role && role !== "all" && !(await isValidUserRole(role))) {
     return res.status(400).json({ error: "Invalid role value" });
   }
 

--- a/github-activity-tracker/backend/routes/orgSummaryRoute.js
+++ b/github-activity-tracker/backend/routes/orgSummaryRoute.js
@@ -12,11 +12,11 @@ router.get('/orgs/:org_id/summary', async (req, res) => {
       return res.status(400).json({ error: 'Invalid org_id' });
     }
 
-    if (!['daily', 'weekly', 'monthly'].includes(period)) {
+    if (!['daily', 'weekly', 'monthly', 'yearly'].includes(period)) {
       return res.status(400).json({ error: 'Invalid period value' });
     }
 
-    if (role && role !== 'all' && !isValidUserRole(role)) {
+    if (role && role !== 'all' && !(await isValidUserRole(role))) {
       return res.status(400).json({ error: 'Invalid role value' });
     }
 

--- a/github-activity-tracker/backend/routes/orgSummaryRoute.js
+++ b/github-activity-tracker/backend/routes/orgSummaryRoute.js
@@ -1,11 +1,12 @@
 const express = require('express');
 const router = express.Router();
 const { getOrgSummary } = require('../services/orgSummaryService');
+const { isValidUserRole } = require('../config/userRoles');
 
 router.get('/orgs/:org_id/summary', async (req, res) => {
   try {
     const { org_id } = req.params;
-    const { period = 'weekly' } = req.query;
+    const { period = 'weekly', role } = req.query;
 
     if (!org_id) {
       return res.status(400).json({ error: 'Invalid org_id' });
@@ -15,7 +16,12 @@ router.get('/orgs/:org_id/summary', async (req, res) => {
       return res.status(400).json({ error: 'Invalid period value' });
     }
 
-    const summary = await getOrgSummary(org_id, period);
+    if (role && role !== 'all' && !isValidUserRole(role)) {
+      return res.status(400).json({ error: 'Invalid role value' });
+    }
+
+    const roleFilter = role && role !== 'all' ? role : null;
+    const summary = await getOrgSummary(org_id, period, roleFilter);
 
     return res.status(200).json(summary);
   } catch (err) {

--- a/github-activity-tracker/backend/routes/orgUsersRoute.js
+++ b/github-activity-tracker/backend/routes/orgUsersRoute.js
@@ -2,6 +2,7 @@ const express = require("express");
 const router = express.Router();
 
 const { getOrgUsers } = require("../services/orgUsersService");
+const { isValidUserRole } = require("../config/userRoles");
 
 router.get("/orgs/:org_id/users", async (req, res) => {
   try {
@@ -10,17 +11,43 @@ router.get("/orgs/:org_id/users", async (req, res) => {
     const period = req.query.period || "weekly";
     const page = parseInt(req.query.page) || 1;
     const limit = parseInt(req.query.limit) || 20;
+    const { role, search, sortBy, sortOrder } = req.query;
 
     if (!org_id || typeof org_id !== "string") {
       return res.status(400).json({ error: "Invalid org_id" });
     }
 
-    if (!["daily", "weekly", "monthly"].includes(period)) {
+    if (!["daily", "weekly", "monthly", "yearly"].includes(period)) {
       return res.status(400).json({ error: "Invalid period value" });
     }
 
-    // pass pagination to service
-    const users = await getOrgUsers(org_id, period, page, limit);
+    if (role && role !== "all" && !(await isValidUserRole(role))) {
+      return res.status(400).json({ error: "Invalid role value" });
+    }
+
+    const roleFilter = role && role !== "all" ? role : null;
+
+    const searchFilter =
+      typeof search === "string" && search.trim() ? search.trim() : null;
+
+    const allowedSortFields = ["prs", "reviews"];
+    const sortByFilter =
+      typeof sortBy === "string" && allowedSortFields.includes(sortBy)
+        ? sortBy
+        : null;
+    const sortOrderFilter =
+      sortOrder === "asc" || sortOrder === "desc" ? sortOrder : "desc";
+
+    const users = await getOrgUsers(
+      org_id,
+      period,
+      page,
+      limit,
+      roleFilter,
+      searchFilter,
+      sortByFilter,
+      sortOrderFilter,
+    );
 
     return res.status(200).json(users);
 

--- a/github-activity-tracker/backend/routes/organizationsRoute.js
+++ b/github-activity-tracker/backend/routes/organizationsRoute.js
@@ -1,0 +1,15 @@
+const express = require('express');
+const router = express.Router();
+const { getAllOrganizations } = require('../services/organizationsService');
+
+router.get('/organizations', async (req, res) => {
+  try {
+    const organizations = await getAllOrganizations();
+    return res.status(200).json(organizations);
+  } catch (error) {
+    console.error('Error fetching organizations:', error);
+    return res.status(500).json({ error: 'Failed to fetch organizations' });
+  }
+});
+
+module.exports = router;

--- a/github-activity-tracker/backend/routes/userDetailsRoute.js
+++ b/github-activity-tracker/backend/routes/userDetailsRoute.js
@@ -1,22 +1,29 @@
 const express = require('express');
 const router = express.Router();
 const { getUserDetails } = require('../services/userDetailsService');
+const { isValidUserRole } = require('../config/userRoles');
 
-// GET /orgs/:org_id/users/:login?period=daily|weekly|monthly
+// GET /orgs/:org_id/users/:login?period=daily|weekly|monthly|yearly&role=Developer
 router.get('/orgs/:org_id/users/:login', async (req, res) => {
   const { org_id, login } = req.params;
-  const { period="weekly" } = req.query;
+  const { period = 'weekly', role } = req.query;
 
   if (!login) {
     return res.status(400).json({ error: 'Missing user login' });
   }
 
-  if (!['daily', 'weekly', 'monthly'].includes(period)) {
+  if (!['daily', 'weekly', 'monthly', 'yearly'].includes(period)) {
     return res.status(400).json({ error: 'Invalid period value' });
   }
 
+  if (role && role !== 'all' && !(await isValidUserRole(role))) {
+    return res.status(400).json({ error: 'Invalid role value' });
+  }
+
+  const roleFilter = role && role !== 'all' ? role : null;
+
   try {
-    const data = await getUserDetails(org_id, login, period);
+    const data = await getUserDetails(org_id, login, period, roleFilter);
     return res.json(data);
   } catch (err) {
     console.error('Error in User Details API:', err);

--- a/github-activity-tracker/backend/routes/userNameSyncRoute.js
+++ b/github-activity-tracker/backend/routes/userNameSyncRoute.js
@@ -1,0 +1,30 @@
+/**
+ * Route: POST /admin/sync/user-names
+ * Backfills GitHub profile display names for users missing name in github_users.
+ */
+const express = require('express');
+const { backfillMissingUserNames } = require('../services/githubUserService');
+const { HTTP, STATUS } = require('../config/errorCodes');
+
+const router = express.Router();
+
+router.post('/admin/sync/user-names', async (req, res) => {
+  try {
+    const result = await backfillMissingUserNames();
+
+    return res.json({
+      status: STATUS.SUCCESS,
+      ...result,
+    });
+  } catch (error) {
+    console.error('Error backfilling GitHub user names:', error);
+
+    return res.status(HTTP.INTERNAL_SERVER_ERROR).json({
+      status: STATUS.ERROR,
+      message: 'Failed to backfill GitHub user names',
+      error: process.env.NODE_ENV === 'development' ? error.message : undefined,
+    });
+  }
+});
+
+module.exports = router;

--- a/github-activity-tracker/backend/routes/userNameSyncRoute.js
+++ b/github-activity-tracker/backend/routes/userNameSyncRoute.js
@@ -10,13 +10,22 @@ const router = express.Router();
 
 router.post('/admin/sync/user-names', async (req, res) => {
   try {
-    const result = await backfillMissingUserNames();
+    const result = await backfillMissingUserNames({
+      limit: req.body?.limit,
+    });
 
     return res.json({
       status: STATUS.SUCCESS,
       ...result,
     });
   } catch (error) {
+    if (error.statusCode === HTTP.BAD_REQUEST) {
+      return res.status(HTTP.BAD_REQUEST).json({
+        status: STATUS.ERROR,
+        message: error.message,
+      });
+    }
+
     console.error('Error backfilling GitHub user names:', error);
 
     return res.status(HTTP.INTERNAL_SERVER_ERROR).json({

--- a/github-activity-tracker/backend/routes/userRoleRoute.js
+++ b/github-activity-tracker/backend/routes/userRoleRoute.js
@@ -1,11 +1,12 @@
 /**
  * Routes:
  *   GET  /admin/users/:login/role  – fetch role for a GitHub user
- *   POST /admin/users/role         – assign role to a GitHub user
+ *   POST /admin/users/role         – assign or change role for a GitHub user
  */
 const express = require('express');
 const { getUserRole, setUserRole } = require('../services/userRoleService');
-const { USER_ROLES } = require('../config/userRoles');
+const { getUserRoleNames } = require('../config/userRoles');
+const { getOrganizationNames } = require('../config/organizations');
 const { HTTP, STATUS } = require('../config/errorCodes');
 
 const router = express.Router();
@@ -47,7 +48,7 @@ router.get('/admin/users/:login/role', async (req, res) => {
 
 router.post('/admin/users/role', async (req, res) => {
   try {
-    const { login, role } = req.body || {};
+    const { login, role, organization } = req.body || {};
 
     if (!login) {
       return res.status(HTTP.BAD_REQUEST).json({
@@ -60,11 +61,19 @@ router.post('/admin/users/role', async (req, res) => {
       return res.status(HTTP.BAD_REQUEST).json({
         status: STATUS.ERROR,
         message: 'role is required in request body',
-        allowed_roles: USER_ROLES,
+        allowed_roles: await getUserRoleNames(),
       });
     }
 
-    const user = await setUserRole({ login, role });
+    if (!organization) {
+      return res.status(HTTP.BAD_REQUEST).json({
+        status: STATUS.ERROR,
+        message: 'organization is required in request body',
+        allowed_organizations: await getOrganizationNames(),
+      });
+    }
+
+    const user = await setUserRole({ login, role, organization });
 
     if (!user) {
       return res.status(HTTP.NOT_FOUND).json({
@@ -83,7 +92,15 @@ router.post('/admin/users/role', async (req, res) => {
       return res.status(HTTP.BAD_REQUEST).json({
         status: STATUS.ERROR,
         message: 'Invalid role value',
-        allowed_roles: USER_ROLES,
+        allowed_roles: await getUserRoleNames(),
+      });
+    }
+
+    if (error.message === 'Invalid organization value') {
+      return res.status(HTTP.BAD_REQUEST).json({
+        status: STATUS.ERROR,
+        message: 'Invalid organization value',
+        allowed_organizations: await getOrganizationNames(),
       });
     }
 

--- a/github-activity-tracker/backend/routes/userRoleRoute.js
+++ b/github-activity-tracker/backend/routes/userRoleRoute.js
@@ -1,0 +1,100 @@
+/**
+ * Routes:
+ *   GET  /admin/users/:login/role  – fetch role for a GitHub user
+ *   POST /admin/users/role         – assign role to a GitHub user
+ */
+const express = require('express');
+const { getUserRole, setUserRole } = require('../services/userRoleService');
+const { USER_ROLES } = require('../config/userRoles');
+const { HTTP, STATUS } = require('../config/errorCodes');
+
+const router = express.Router();
+
+router.get('/admin/users/:login/role', async (req, res) => {
+  try {
+    const { login } = req.params;
+
+    if (!login) {
+      return res.status(HTTP.BAD_REQUEST).json({
+        status: STATUS.ERROR,
+        message: 'login is required',
+      });
+    }
+
+    const user = await getUserRole(login);
+
+    if (!user) {
+      return res.status(HTTP.NOT_FOUND).json({
+        status: STATUS.ERROR,
+        message: 'User not found',
+      });
+    }
+
+    return res.json({
+      status: STATUS.SUCCESS,
+      user,
+    });
+  } catch (error) {
+    console.error('Error fetching user role:', error);
+
+    return res.status(HTTP.INTERNAL_SERVER_ERROR).json({
+      status: STATUS.ERROR,
+      message: 'Failed to fetch user role',
+      error: process.env.NODE_ENV === 'development' ? error.message : undefined,
+    });
+  }
+});
+
+router.post('/admin/users/role', async (req, res) => {
+  try {
+    const { login, role } = req.body || {};
+
+    if (!login) {
+      return res.status(HTTP.BAD_REQUEST).json({
+        status: STATUS.ERROR,
+        message: 'login is required in request body',
+      });
+    }
+
+    if (!role) {
+      return res.status(HTTP.BAD_REQUEST).json({
+        status: STATUS.ERROR,
+        message: 'role is required in request body',
+        allowed_roles: USER_ROLES,
+      });
+    }
+
+    const user = await setUserRole({ login, role });
+
+    if (!user) {
+      return res.status(HTTP.NOT_FOUND).json({
+        status: STATUS.ERROR,
+        message: 'User not found',
+      });
+    }
+
+    return res.json({
+      status: STATUS.SUCCESS,
+      message: 'Role assigned successfully',
+      user,
+    });
+  } catch (error) {
+    if (error.message === 'Invalid role value') {
+      return res.status(HTTP.BAD_REQUEST).json({
+        status: STATUS.ERROR,
+        message: 'Invalid role value',
+        allowed_roles: USER_ROLES,
+      });
+    }
+
+    console.error('Error assigning user role:', error);
+
+    return res.status(HTTP.INTERNAL_SERVER_ERROR).json({
+      status: STATUS.ERROR,
+      message: 'Failed to assign user role',
+      error: process.env.NODE_ENV === 'development' ? error.message : undefined,
+    });
+  }
+});
+
+module.exports = router;

--- a/github-activity-tracker/backend/routes/userRolesRoute.js
+++ b/github-activity-tracker/backend/routes/userRolesRoute.js
@@ -1,0 +1,15 @@
+const express = require('express');
+const router = express.Router();
+const { getAllUserRoles } = require('../services/userRolesService');
+
+router.get('/user-roles', async (req, res) => {
+  try {
+    const roles = await getAllUserRoles();
+    return res.status(200).json(roles);
+  } catch (error) {
+    console.error('Error fetching user roles:', error);
+    return res.status(500).json({ error: 'Failed to fetch user roles' });
+  }
+});
+
+module.exports = router;

--- a/github-activity-tracker/backend/scripts/runSync.js
+++ b/github-activity-tracker/backend/scripts/runSync.js
@@ -1,0 +1,98 @@
+/**
+ * Full GitHub data sync: repos → commits → PRs → reviews → user names.
+ */
+require('dotenv').config({ path: require('path').join(__dirname, '..', '.env') });
+const { syncRepos } = require('../services/syncRepos');
+const { syncCommits } = require('../services/commitSyncService');
+const { syncPRs } = require('../services/prSyncService');
+const { syncReviews } = require('../services/reviewSyncService');
+const { backfillMissingUserNames } = require('../services/githubUserService');
+const pool = require('../db/dbPool');
+const { DELAY_BETWEEN_REPOS_MS } = require('../config/syncConfig');
+
+function parseOrgs() {
+  return (process.env.GITHUB_ORG || '')
+    .split(',')
+    .map((value) => value.trim())
+    .filter(Boolean);
+}
+
+async function loadRepos() {
+  const result = await pool.query(
+    'SELECT github_repo_id, owner, name, full_name FROM repos ORDER BY github_repo_id'
+  );
+  return result.rows;
+}
+
+async function syncAllRepos(orgs) {
+  let reposProcessed = 0;
+  for (const org of orgs) {
+    reposProcessed += await syncRepos(org);
+  }
+  return reposProcessed;
+}
+
+async function syncForAllRepos(label, syncFn) {
+  const repos = await loadRepos();
+  let processed = 0;
+  let total = 0;
+
+  for (let i = 0; i < repos.length; i += 1) {
+    const repo = repos[i];
+    const repoName = repo.full_name || `${repo.owner}/${repo.name}`;
+
+    try {
+      console.log(`[${label} ${i + 1}/${repos.length}] ${repoName}`);
+      const count = await syncFn(repo.github_repo_id);
+      processed += count;
+      console.log(`  done: ${count} ${label}`);
+    } catch (error) {
+      console.error(`  error for ${repoName}:`, error.message);
+    }
+
+    if (i < repos.length - 1) {
+      await new Promise((resolve) => setTimeout(resolve, DELAY_BETWEEN_REPOS_MS));
+    }
+  }
+
+  return { repos_processed: repos.length, total_repos: repos.length, [`${label}_processed`]: processed };
+}
+
+async function main() {
+  const orgs = parseOrgs();
+  if (orgs.length === 0) {
+    throw new Error('Set GITHUB_ORG in backend/.env');
+  }
+
+  console.log('=== GitHub Activity Tracker – full sync ===');
+  console.log(`Organizations: ${orgs.join(', ')}\n`);
+
+  console.log('1/5 Syncing repositories...');
+  const reposProcessed = await syncAllRepos(orgs);
+  console.log(`Repos result: ${reposProcessed} repos\n`);
+
+  console.log('2/5 Syncing commits...');
+  const commitsResult = await syncForAllRepos('commits', syncCommits);
+  console.log('Commits result:', commitsResult, '\n');
+
+  console.log('3/5 Syncing pull requests...');
+  const prsResult = await syncForAllRepos('prs', syncPRs);
+  console.log('PRs result:', prsResult, '\n');
+
+  console.log('4/5 Syncing reviews...');
+  const reviewsResult = await syncForAllRepos('reviews', syncReviews);
+  console.log('Reviews result:', reviewsResult, '\n');
+
+  console.log('5/5 Backfilling user names...');
+  const namesUpdated = await backfillMissingUserNames();
+  console.log(`User names updated: ${namesUpdated}\n`);
+
+  console.log('=== Sync complete ===');
+}
+
+main()
+  .catch((error) => {
+    console.error('Sync failed:', error);
+    process.exitCode = 1;
+  })
+  .finally(() => pool.end());

--- a/github-activity-tracker/backend/services/commitSyncService.js
+++ b/github-activity-tracker/backend/services/commitSyncService.js
@@ -2,6 +2,7 @@ const githubClient = require('../utils/githubClient');
 const pool = require('../db/dbPool');
 const { POSTGRES } = require('../config/errorCodes');
 const { isExcludedGitHubLogin } = require('../config/excludedGitHubLogins');
+const { upsertGitHubUser } = require('./githubUserService');
 
 /**
  * Sync commits for a single repository.
@@ -120,23 +121,13 @@ async function syncCommits(repoId) {
             continue;
           }
 
-          // Ensure user exists; get our internal id for foreign keys
-          const userResult = await pool.query(
-            `
-              INSERT INTO github_users (github_user_id, login, avatar_url, html_url, type)
-              VALUES ($1, $2, $3, $4, $5)
-              ON CONFLICT (github_user_id)
-              DO UPDATE SET
-                login = EXCLUDED.login,
-                avatar_url = EXCLUDED.avatar_url,
-                html_url = EXCLUDED.html_url,
-                type = EXCLUDED.type
-              RETURNING id
-            `,
-            [github_user_id, login, avatar_url || null, html_url || null, type || null]
-          );
-
-          const userId = userResult.rows[0].id;
+          const userId = await upsertGitHubUser({
+            github_user_id,
+            login,
+            avatar_url,
+            html_url,
+            type,
+          });
 
           // Record event first; only increment commit counters when the event is newly inserted.
           const eventInsert = await pool.query(

--- a/github-activity-tracker/backend/services/githubUserService.js
+++ b/github-activity-tracker/backend/services/githubUserService.js
@@ -1,0 +1,150 @@
+const githubClient = require('../utils/githubClient');
+const pool = require('../db/dbPool');
+
+const NAME_FETCH_DELAY_MS = 120;
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function isBotType(type) {
+  return String(type || '').toLowerCase() === 'bot';
+}
+
+/**
+ * Fetch GitHub profile display name for a login. Returns null when unset or on failure.
+ */
+async function fetchGitHubUserName(login) {
+  if (!login) return null;
+
+  try {
+    const { data } = await githubClient.get(`/users/${encodeURIComponent(login)}`);
+    const name = data?.name;
+    return name && String(name).trim() ? String(name).trim() : null;
+  } catch (error) {
+    const status = error?.response?.status;
+    if (status === 404) {
+      console.warn(`GitHub user not found while fetching name: ${login}`);
+      return null;
+    }
+    console.warn(`Failed to fetch GitHub name for ${login}:`, error.message);
+    return null;
+  }
+}
+
+/**
+ * Resolve display name: use provided value, existing DB value, or fetch from GitHub.
+ */
+async function resolveGitHubUserName({ github_user_id, login, type, name }) {
+  if (name && String(name).trim()) {
+    return String(name).trim();
+  }
+
+  if (!login || isBotType(type)) {
+    return null;
+  }
+
+  const existing = await pool.query(
+    'SELECT name FROM github_users WHERE github_user_id = $1',
+    [github_user_id]
+  );
+
+  const storedName = existing.rows[0]?.name;
+  if (storedName && String(storedName).trim()) {
+    return String(storedName).trim();
+  }
+
+  return fetchGitHubUserName(login);
+}
+
+/**
+ * Upsert a GitHub user and return the internal github_users.id.
+ */
+async function upsertGitHubUser({
+  github_user_id,
+  login,
+  avatar_url,
+  html_url,
+  type,
+  name,
+}) {
+  const displayName = await resolveGitHubUserName({
+    github_user_id,
+    login,
+    type,
+    name,
+  });
+
+  const userResult = await pool.query(
+    `
+      INSERT INTO github_users (github_user_id, login, avatar_url, html_url, type, name)
+      VALUES ($1, $2, $3, $4, $5, $6)
+      ON CONFLICT (github_user_id)
+      DO UPDATE SET
+        login = EXCLUDED.login,
+        avatar_url = EXCLUDED.avatar_url,
+        html_url = EXCLUDED.html_url,
+        type = EXCLUDED.type,
+        name = COALESCE(EXCLUDED.name, github_users.name),
+        updated_at = CURRENT_TIMESTAMP
+      RETURNING id
+    `,
+    [
+      github_user_id,
+      login,
+      avatar_url || null,
+      html_url || null,
+      type || null,
+      displayName,
+    ]
+  );
+
+  return userResult.rows[0].id;
+}
+
+/**
+ * Backfill profile names for users that do not have one stored yet.
+ */
+async function backfillMissingUserNames() {
+  const result = await pool.query(
+    `
+      SELECT id, login, type
+      FROM github_users
+      WHERE name IS NULL
+        AND login IS NOT NULL
+        AND (type IS NULL OR LOWER(type) <> 'bot')
+      ORDER BY id
+    `
+  );
+
+  let namesFetched = 0;
+
+  for (const user of result.rows) {
+    const name = await fetchGitHubUserName(user.login);
+    await pool.query(
+      `
+        UPDATE github_users
+        SET name = $1, updated_at = CURRENT_TIMESTAMP
+        WHERE id = $2
+      `,
+      [name, user.id]
+    );
+
+    if (name) {
+      namesFetched += 1;
+    }
+
+    await sleep(NAME_FETCH_DELAY_MS);
+  }
+
+  return {
+    users_checked: result.rows.length,
+    names_fetched: namesFetched,
+  };
+}
+
+module.exports = {
+  fetchGitHubUserName,
+  upsertGitHubUser,
+  backfillMissingUserNames,
+};

--- a/github-activity-tracker/backend/services/githubUserService.js
+++ b/github-activity-tracker/backend/services/githubUserService.js
@@ -11,6 +11,14 @@ function isBotType(type) {
   return String(type || '').toLowerCase() === 'bot';
 }
 
+function normalizeDisplayName(name) {
+  if (!name || !String(name).trim()) {
+    return null;
+  }
+
+  return String(name).trim();
+}
+
 /**
  * Fetch GitHub profile display name for a login. Returns null when unset or on failure.
  */
@@ -33,11 +41,12 @@ async function fetchGitHubUserName(login) {
 }
 
 /**
- * Resolve display name: use provided value, existing DB value, or fetch from GitHub.
+ * Resolve display name: use provided value, existing github_users value, or fetch from GitHub.
  */
 async function resolveGitHubUserName({ github_user_id, login, type, name }) {
-  if (name && String(name).trim()) {
-    return String(name).trim();
+  const providedName = normalizeDisplayName(name);
+  if (providedName) {
+    return providedName;
   }
 
   if (!login || isBotType(type)) {
@@ -45,16 +54,46 @@ async function resolveGitHubUserName({ github_user_id, login, type, name }) {
   }
 
   const existing = await pool.query(
-    'SELECT name FROM github_users WHERE github_user_id = $1',
+    `
+      SELECT name
+      FROM github_users
+      WHERE github_user_id = $1
+    `,
     [github_user_id]
   );
 
-  const storedName = existing.rows[0]?.name;
-  if (storedName && String(storedName).trim()) {
-    return String(storedName).trim();
+  const storedName = normalizeDisplayName(existing.rows[0]?.name);
+  if (storedName) {
+    return storedName;
   }
 
   return fetchGitHubUserName(login);
+}
+
+/**
+ * Ensure the user has an active user_details row.
+ */
+async function ensureActiveUserDetails(userId) {
+  const activeResult = await pool.query(
+    `
+      SELECT id
+      FROM user_details
+      WHERE user_id = $1 AND active = true
+    `,
+    [userId]
+  );
+
+  if (activeResult.rows[0]) {
+    return;
+  }
+
+  await pool.query(
+    `
+      INSERT INTO user_details (user_id, role_id, active, active_from, active_to)
+      VALUES ($1, NULL, true, '1970-01-01'::timestamp, NULL)
+    `,
+    [userId]
+  );
 }
 
 /**
@@ -99,21 +138,23 @@ async function upsertGitHubUser({
     ]
   );
 
-  return userResult.rows[0].id;
+  const userId = userResult.rows[0].id;
+  await ensureActiveUserDetails(userId);
+  return userId;
 }
 
 /**
- * Backfill profile names for users that do not have one stored yet.
+ * Backfill profile names for users that do not have one stored in github_users yet.
  */
 async function backfillMissingUserNames() {
   const result = await pool.query(
     `
-      SELECT id, login, type
-      FROM github_users
-      WHERE name IS NULL
-        AND login IS NOT NULL
-        AND (type IS NULL OR LOWER(type) <> 'bot')
-      ORDER BY id
+      SELECT u.id, u.login, u.type, u.github_user_id
+      FROM github_users u
+      WHERE u.name IS NULL
+        AND u.login IS NOT NULL
+        AND (u.type IS NULL OR LOWER(u.type) <> 'bot')
+      ORDER BY u.id
     `
   );
 
@@ -121,18 +162,20 @@ async function backfillMissingUserNames() {
 
   for (const user of result.rows) {
     const name = await fetchGitHubUserName(user.login);
-    await pool.query(
-      `
-        UPDATE github_users
-        SET name = $1, updated_at = CURRENT_TIMESTAMP
-        WHERE id = $2
-      `,
-      [name, user.id]
-    );
 
     if (name) {
+      await pool.query(
+        `
+          UPDATE github_users
+          SET name = $1, updated_at = CURRENT_TIMESTAMP
+          WHERE id = $2
+        `,
+        [name, user.id]
+      );
       namesFetched += 1;
     }
+
+    await ensureActiveUserDetails(user.id);
 
     await sleep(NAME_FETCH_DELAY_MS);
   }
@@ -147,4 +190,5 @@ module.exports = {
   fetchGitHubUserName,
   upsertGitHubUser,
   backfillMissingUserNames,
+  ensureActiveUserDetails,
 };

--- a/github-activity-tracker/backend/services/leaderBoardService.js
+++ b/github-activity-tracker/backend/services/leaderBoardService.js
@@ -36,6 +36,7 @@ const getLeaderboard = async (orgId, period = "weekly", limit = 10) => {
   let query = `
     SELECT
       u.login,
+      u.name,
       u.avatar_url AS avatar,
       COUNT(*) FILTER (WHERE e.event_type = 'commit') AS commits,
       COUNT(*) FILTER (WHERE e.event_type = 'pr') AS prs,
@@ -69,7 +70,7 @@ const getLeaderboard = async (orgId, period = "weekly", limit = 10) => {
   }
 
   query += `
-    GROUP BY u.id, u.login, u.avatar_url
+    GROUP BY u.id, u.login, u.name, u.avatar_url
     ORDER BY score DESC
     LIMIT ${limit};
   `;
@@ -79,6 +80,7 @@ const getLeaderboard = async (orgId, period = "weekly", limit = 10) => {
   const leaderboard = result.rows.map((row, index) => ({
     rank: index + 1,
     login: row.login,
+    name: row.name || null,
     avatar: row.avatar,
     commits: Number(row.commits),
     prs: Number(row.prs),

--- a/github-activity-tracker/backend/services/leaderBoardService.js
+++ b/github-activity-tracker/backend/services/leaderBoardService.js
@@ -9,7 +9,7 @@ function getDateRange(period) {
     return { start: null, end: null };
   }
 
-  const periods = { daily: 1, weekly: 7, monthly: 30 };
+  const periods = { daily: 1, weekly: 7, monthly: 30, yearly: 365 };
   const days = periods[period];
   if (!days) {
     throw new Error('Invalid period');
@@ -36,7 +36,7 @@ const getLeaderboard = async (orgId, period = "weekly", limit = 10) => {
   let query = `
     SELECT
       u.login,
-      u.name,
+      u.name AS name,
       u.avatar_url AS avatar,
       COUNT(*) FILTER (WHERE e.event_type = 'commit') AS commits,
       COUNT(*) FILTER (WHERE e.event_type = 'pr') AS prs,

--- a/github-activity-tracker/backend/services/orgActivityService.js
+++ b/github-activity-tracker/backend/services/orgActivityService.js
@@ -5,7 +5,7 @@ const { EXCLUDED_GITHUB_LOGINS } = require("../config/excludedGitHubLogins");
 /**
  * Returns org-wide daily activity for chosen period, scoped to repos owned by orgId.
  */
-async function getOrgActivity(orgId, period) {
+async function getOrgActivity(orgId, period, role) {
   const periods = { daily: 1, weekly: 7, monthly: 30 };
   const days = periods[period];
   if (!days) {
@@ -21,6 +21,11 @@ async function getOrgActivity(orgId, period) {
   if (Array.isArray(EXCLUDED_GITHUB_LOGINS) && EXCLUDED_GITHUB_LOGINS.length > 0) {
     params.push(EXCLUDED_GITHUB_LOGINS.map((l) => String(l).toLowerCase()));
     whereClauses.push(`LOWER(u.login) <> ALL($${params.length})`);
+  }
+
+  if (role) {
+    params.push(role);
+    whereClauses.push(`u.role = $${params.length}`);
   }
 
   params.push(start.toDate(), end.toDate());

--- a/github-activity-tracker/backend/services/orgActivityService.js
+++ b/github-activity-tracker/backend/services/orgActivityService.js
@@ -1,81 +1,163 @@
 const pool = require("../db/dbPool");
+
 const dayjs = require("dayjs");
+
 const { EXCLUDED_GITHUB_LOGINS } = require("../config/excludedGitHubLogins");
+const { userDetailsJoinSql } = require("../utils/userRoleSql");
+
+
 
 /**
+
  * Returns org-wide daily activity for chosen period, scoped to repos owned by orgId.
+
  */
+
 async function getOrgActivity(orgId, period, role) {
-  const periods = { daily: 1, weekly: 7, monthly: 30 };
+
+  const periods = { daily: 1, weekly: 7, monthly: 30, yearly: 365 };
+
   const days = periods[period];
+
   if (!days) {
+
     throw new Error("Invalid period");
+
   }
+
+
 
   const end = dayjs().endOf("day");
+
   const start = end.subtract(days - 1, "day").startOf("day");
 
+
+
   const params = [String(orgId).toLowerCase()];
+
   const whereClauses = [`LOWER(r.owner) = $${params.length}`];
 
+
+
   if (Array.isArray(EXCLUDED_GITHUB_LOGINS) && EXCLUDED_GITHUB_LOGINS.length > 0) {
+
     params.push(EXCLUDED_GITHUB_LOGINS.map((l) => String(l).toLowerCase()));
+
     whereClauses.push(`LOWER(u.login) <> ALL($${params.length})`);
+
   }
+
+
+
+  params.push(start.toDate(), end.toDate());
+
+  whereClauses.push(`e.created_at BETWEEN $${params.length - 1} AND $${params.length}`);
+
+
+
+  let userDetailsJoin = userDetailsJoinSql(null);
 
   if (role) {
     params.push(role);
-    whereClauses.push(`u.role = $${params.length}`);
+    userDetailsJoin = userDetailsJoinSql(`$${params.length}`);
   }
 
-  params.push(start.toDate(), end.toDate());
-  whereClauses.push(`e.created_at BETWEEN $${params.length - 1} AND $${params.length}`);
+
 
   const result = await pool.query(
+
     `
+
     SELECT
+
       DATE(e.created_at) AS date,
+
       COUNT(*) FILTER (WHERE e.event_type = 'commit') AS commits,
+
       COUNT(*) FILTER (WHERE e.event_type = 'pr') AS prs,
+
       COUNT(*) FILTER (WHERE e.event_type = 'review') AS reviews
+
     FROM activity_events e
+
     JOIN github_users u ON u.id = e.user_id
+
+    ${userDetailsJoin}
+
     JOIN repos r ON r.github_repo_id = e.repo_id
+
     WHERE ${whereClauses.join(" AND ")}
+
     GROUP BY DATE(e.created_at)
+
     ORDER BY DATE(e.created_at);
+
     `,
+
     params
+
   );
 
-  // Generate empty date → fill zeros
+
+
   const labels = [];
+
   const commits = [];
+
   const prs = [];
+
   const reviews = [];
+
   const total = [];
 
+
+
   const map = {};
+
   result.rows.forEach((r) => {
+
     map[dayjs(r.date).format("YYYY-MM-DD")] = r;
+
   });
 
+
+
   for (let i = 0; i < days; i++) {
+
     const d = start.add(i, "day").format("YYYY-MM-DD");
+
     labels.push(d);
+
+
 
     const row = map[d] || { commits: 0, prs: 0, reviews: 0 };
 
+
+
     const c = Number(row.commits);
+
     const p = Number(row.prs);
+
     const r = Number(row.reviews);
+
     commits.push(c);
+
     prs.push(p);
+
     reviews.push(r);
+
     total.push(c + p + r);
+
   }
 
+
+
   return { labels, commits, prs, reviews, total };
+
 }
 
+
+
 module.exports = { getOrgActivity };
+
+

--- a/github-activity-tracker/backend/services/orgSummaryService.js
+++ b/github-activity-tracker/backend/services/orgSummaryService.js
@@ -50,7 +50,7 @@ function getDateRanges(period) {
   };
 }
 
-async function fetchCounts(orgId, start, end) {
+async function fetchCounts(orgId, start, end, role) {
   const params = [];
   let query = `
     SELECT event_type, COUNT(*) AS count
@@ -67,6 +67,11 @@ async function fetchCounts(orgId, start, end) {
   if (Array.isArray(EXCLUDED_GITHUB_LOGINS) && EXCLUDED_GITHUB_LOGINS.length > 0) {
     params.push(EXCLUDED_GITHUB_LOGINS.map((l) => String(l).toLowerCase()));
     whereClauses.push(`LOWER(u.login) <> ALL($${params.length})`);
+  }
+
+  if (role) {
+    params.push(role);
+    whereClauses.push(`u.role = $${params.length}`);
   }
 
   params.push(start, end);
@@ -114,12 +119,12 @@ function calculateChange(current, previous) {
   };
 }
 
-async function getOrgSummary(orgId, period) {
+async function getOrgSummary(orgId, period, role) {
   const { currentStart, currentEnd, previousStart, previousEnd } =
     getDateRanges(period);
 
-  const current = await fetchCounts(orgId, currentStart, currentEnd);
-  const previous = await fetchCounts(orgId, previousStart, previousEnd);
+  const current = await fetchCounts(orgId, currentStart, currentEnd, role);
+  const previous = await fetchCounts(orgId, previousStart, previousEnd, role);
 
   const change = calculateChange(current, previous);
 

--- a/github-activity-tracker/backend/services/orgSummaryService.js
+++ b/github-activity-tracker/backend/services/orgSummaryService.js
@@ -1,142 +1,309 @@
 const db = require("../db/dbPool");
+
 const { EXCLUDED_GITHUB_LOGINS } = require("../config/excludedGitHubLogins");
+const { userDetailsJoinSql } = require("../utils/userRoleSql");
+
+
 
 function getDateRanges(period) {
+
   const now = new Date();
+
+
 
   let currentStart, previousStart, currentEnd, previousEnd;
 
+
+
   switch (period) {
+
     case "daily":
+
       currentStart = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+
       previousStart = new Date(currentStart);
+
       previousStart.setDate(previousStart.getDate() - 1);
 
-      currentEnd = new Date(now); // now
+
+
+      currentEnd = new Date(now);
+
       previousEnd = new Date(currentStart);
+
       break;
+
+
 
     case "weekly":
+
       currentStart = new Date();
+
       currentStart.setDate(currentStart.getDate() - 7);
 
+
+
       previousStart = new Date();
+
       previousStart.setDate(previousStart.getDate() - 14);
 
-      currentEnd = new Date(); // now
+
+
+      currentEnd = new Date(now);
+
       previousEnd = new Date(currentStart);
+
       break;
+
+
 
     case "monthly":
+
       currentStart = new Date();
+
       currentStart.setDate(currentStart.getDate() - 30);
 
+
+
       previousStart = new Date();
+
       previousStart.setDate(previousStart.getDate() - 60);
 
-      currentEnd = new Date(); // now
+
+
+      currentEnd = new Date(now);
+
       previousEnd = new Date(currentStart);
+
       break;
 
+
+
+    case "yearly":
+
+      currentStart = new Date();
+
+      currentStart.setDate(currentStart.getDate() - 365);
+
+
+
+      previousStart = new Date();
+
+      previousStart.setDate(previousStart.getDate() - 730);
+
+
+
+      currentEnd = new Date(now);
+
+      previousEnd = new Date(currentStart);
+
+      break;
+
+
+
     default:
+
       throw new Error("Invalid period value");
+
   }
 
+
+
   return {
+
     currentStart,
+
     currentEnd,
+
     previousStart,
+
     previousEnd,
+
   };
+
 }
 
+
+
 async function fetchCounts(orgId, start, end, role) {
+
   const params = [];
+
   let query = `
+
     SELECT event_type, COUNT(*) AS count
+
     FROM activity_events e
+
     JOIN github_users u ON u.id = e.user_id
+
     JOIN repos r ON r.github_repo_id = e.repo_id
+
   `;
+
+
 
   const whereClauses = [];
 
+
+
   params.push(String(orgId).toLowerCase());
+
   whereClauses.push(`LOWER(r.owner) = $${params.length}`);
 
+
+
   if (Array.isArray(EXCLUDED_GITHUB_LOGINS) && EXCLUDED_GITHUB_LOGINS.length > 0) {
+
     params.push(EXCLUDED_GITHUB_LOGINS.map((l) => String(l).toLowerCase()));
+
     whereClauses.push(`LOWER(u.login) <> ALL($${params.length})`);
+
   }
+
+
+
+  params.push(start, end);
+
+  whereClauses.push(`e.created_at BETWEEN $${params.length - 1} AND $${params.length}`);
+
+
+
+  let userDetailsJoin = userDetailsJoinSql(null);
 
   if (role) {
     params.push(role);
-    whereClauses.push(`u.role = $${params.length}`);
+    userDetailsJoin = userDetailsJoinSql(`$${params.length}`);
   }
 
-  params.push(start, end);
-  whereClauses.push(`e.created_at BETWEEN $${params.length - 1} AND $${params.length}`);
+
 
   query += `
+
+    ${userDetailsJoin}
+
     WHERE ${whereClauses.join(" AND ")}
+
     GROUP BY event_type;
+
   `;
+
+
 
   const result = await db.query(query, params);
 
+
+
   const summary = {
+
     commits: 0,
+
     prs: 0,
+
     reviews: 0,
+
     activity: 0,
+
   };
+
+
 
   result.rows.forEach((row) => {
+
     if (row.event_type === "commit") summary.commits = Number(row.count);
+
     if (row.event_type === "pr") summary.prs = Number(row.count);
+
     if (row.event_type === "review") summary.reviews = Number(row.count);
+
   });
 
-  summary.activity = summary.commits + summary.prs + summary.reviews;
+
+
+  summary.activity = summary.prs + summary.reviews;
+
+
 
   return summary;
+
 }
+
+
 
 function calculateChange(current, previous) {
+
   const safePercent = (c, p) => {
+
     if (p === 0) {
+
       return c === 0 ? 0 : 100;
+
     }
 
+
+
     return Number((((c - p) / p) * 100).toFixed(1));
+
   };
+
+
 
   return {
+
     commits: safePercent(current.commits, previous.commits),
+
     prs: safePercent(current.prs, previous.prs),
+
     reviews: safePercent(current.reviews, previous.reviews),
+
     activity: safePercent(current.activity, previous.activity),
+
   };
+
 }
 
+
+
 async function getOrgSummary(orgId, period, role) {
+
   const { currentStart, currentEnd, previousStart, previousEnd } =
+
     getDateRanges(period);
 
+
+
   const current = await fetchCounts(orgId, currentStart, currentEnd, role);
+
   const previous = await fetchCounts(orgId, previousStart, previousEnd, role);
+
+
 
   const change = calculateChange(current, previous);
 
+
+
   return {
+
     total_commits: current.commits,
+
     total_prs: current.prs,
+
     total_reviews: current.reviews,
+
     total_activity: current.activity,
+
     change,
+
   };
+
 }
 
+
+
 module.exports = {
+
   getOrgSummary,
+
 };
+
+

--- a/github-activity-tracker/backend/services/orgUsersService.js
+++ b/github-activity-tracker/backend/services/orgUsersService.js
@@ -3,19 +3,17 @@ const { EXCLUDED_GITHUB_LOGINS } = require("../config/excludedGitHubLogins");
 
 const DEFAULT_LIMIT = 20;
 
-/* ------------------------------------------------
-   Determine date ranges for daily/weekly/monthly
------------------------------------------------- */
 function getDateRanges(period) {
   const periods = {
     daily: 1,
     weekly: 7,
     monthly: 30,
+    yearly: 365,
   };
 
   const days = periods[period];
   if (!days) {
-    throw new Error('Invalid period');
+    throw new Error("Invalid period");
   }
 
   const end = new Date();
@@ -26,7 +24,6 @@ function getDateRanges(period) {
   start.setUTCHours(0, 0, 0, 0);
 
   const prevEnd = new Date(start.getTime() - 1);
-
   const prevStart = new Date(prevEnd);
   prevStart.setUTCDate(prevEnd.getUTCDate() - (days - 1));
   prevStart.setUTCHours(0, 0, 0, 0);
@@ -34,148 +31,174 @@ function getDateRanges(period) {
   return { start, end, prevStart, prevEnd };
 }
 
-/* -----------------------------------------------
-   Difference helper
------------------------------------------------- */
 function diff(current, previous) {
   return current - previous;
 }
 
-/* ------------------------------------------------
-   MAIN FUNCTION WITH PAGINATION
------------------------------------------------- */
+function sortUsers(results, sortBy, sortOrder) {
+  const direction = sortOrder === "asc" ? 1 : -1;
+
+  if (sortBy === "prs") {
+    results.sort((a, b) => (a.prs - b.prs) * direction);
+    return;
+  }
+
+  if (sortBy === "reviews") {
+    results.sort((a, b) => (a.reviews - b.reviews) * direction);
+    return;
+  }
+
+  results.sort((a, b) => {
+    if (b.total_activity !== a.total_activity) {
+      return b.total_activity - a.total_activity;
+    }
+    if (a.is_active !== b.is_active) {
+      return a.is_active ? -1 : 1;
+    }
+    return String(a.login).localeCompare(String(b.login));
+  });
+}
+
+async function fetchAssignments(role) {
+  const params = [];
+  let query = `
+    SELECT
+      ud.id AS assignment_id,
+      u.id AS user_id,
+      u.login AS login,
+      u.name AS name,
+      u.avatar_url AS avatar,
+      ur.name AS role,
+      ud.active AS is_active,
+      ud.active_from AS active_from,
+      ud.active_to AS active_to
+    FROM github_users u
+    JOIN user_details ud ON ud.user_id = u.id
+    LEFT JOIN user_roles ur ON ur.id = ud.role_id
+  `;
+
+  const whereClauses = ["(ud.active = true OR ud.role_id IS NOT NULL)"];
+
+  if (Array.isArray(EXCLUDED_GITHUB_LOGINS) && EXCLUDED_GITHUB_LOGINS.length > 0) {
+    params.push(EXCLUDED_GITHUB_LOGINS.map((l) => String(l).toLowerCase()));
+    whereClauses.push(`LOWER(u.login) <> ALL($${params.length})`);
+  }
+
+  if (role) {
+    params.push(role);
+    whereClauses.push(`ur.name = $${params.length}`);
+  }
+
+  query += ` WHERE ${whereClauses.join(" AND ")} `;
+  query += " ORDER BY u.login ASC, ud.active DESC, ud.active_from DESC, ud.id DESC";
+
+  const result = await db.query(query, params);
+  return result.rows;
+}
+
+async function fetchAssignmentActivityMap(orgId, role, start, end) {
+  const params = [String(orgId).toLowerCase()];
+  let query = `
+    SELECT
+      ud.id AS assignment_id,
+      COUNT(*) FILTER (WHERE e.event_type = 'commit') AS commits,
+      COUNT(*) FILTER (WHERE e.event_type = 'pr') AS prs,
+      COUNT(*) FILTER (WHERE e.event_type = 'review') AS reviews
+    FROM activity_events e
+    JOIN github_users u ON u.id = e.user_id
+    JOIN repos r ON r.github_repo_id = e.repo_id
+    JOIN user_details ud ON ud.user_id = e.user_id
+      AND ud.active_from <= e.created_at
+      AND (ud.active_to IS NULL OR e.created_at < ud.active_to)
+    LEFT JOIN user_roles ur ON ur.id = ud.role_id
+    WHERE LOWER(r.owner) = $1
+      AND (ud.active = true OR ud.role_id IS NOT NULL)
+  `;
+
+  if (Array.isArray(EXCLUDED_GITHUB_LOGINS) && EXCLUDED_GITHUB_LOGINS.length > 0) {
+    params.push(EXCLUDED_GITHUB_LOGINS.map((l) => String(l).toLowerCase()));
+    query += ` AND LOWER(u.login) <> ALL($${params.length})`;
+  }
+
+  if (role) {
+    params.push(role);
+    query += ` AND ur.name = $${params.length}`;
+  }
+
+  params.push(start.toISOString(), end.toISOString());
+  query += ` AND e.created_at BETWEEN $${params.length - 1} AND $${params.length}`;
+  query += " GROUP BY ud.id";
+
+  const result = await db.query(query, params);
+  const map = {};
+
+  result.rows.forEach((row) => {
+    map[row.assignment_id] = {
+      commits: Number(row.commits) || 0,
+      prs: Number(row.prs) || 0,
+      reviews: Number(row.reviews) || 0,
+    };
+  });
+
+  return map;
+}
+
 const getOrgUsers = async (
   orgId,
   period = "weekly",
   page = 1,
   limit = DEFAULT_LIMIT,
+  role = null,
+  search = null,
+  sortBy = null,
+  sortOrder = "desc"
 ) => {
-  // ensure numbers
-  page = parseInt(page) || 1;
-  limit = parseInt(limit) || DEFAULT_LIMIT;
+  page = parseInt(page, 10) || 1;
+  limit = parseInt(limit, 10) || DEFAULT_LIMIT;
 
   const { start, end, prevStart, prevEnd } = getDateRanges(period);
+  const assignments = await fetchAssignments(role);
+  const currentMap = await fetchAssignmentActivityMap(orgId, role, start, end);
+  const previousMap = await fetchAssignmentActivityMap(orgId, role, prevStart, prevEnd);
 
-  /* 1️⃣ Fetch users */
-  const usersParams = [];
-  let usersQuery = `
-    SELECT
-      u.id,
-      u.login AS login,
-      u.name AS name,
-      u.avatar_url AS avatar,
-      u.role AS role
-    FROM github_users u
-  `;
-
-  if (Array.isArray(EXCLUDED_GITHUB_LOGINS) && EXCLUDED_GITHUB_LOGINS.length > 0) {
-    usersParams.push(EXCLUDED_GITHUB_LOGINS.map((l) => String(l).toLowerCase()));
-    usersQuery += ` WHERE LOWER(u.login) <> ALL($${usersParams.length}) `;
-  }
-
-  usersQuery += `
-    ORDER BY u.login ASC;
-  `;
-
-  const usersRes = await db.query(usersQuery, usersParams);
-  const users = usersRes.rows;
-
-  /* 2️⃣ Current period activity */
-  const activityParamsBase = [];
-  let activityQuery = `
-    SELECT
-      e.user_id AS user_id,
-      COUNT(*) FILTER (WHERE event_type = 'commit') AS commits,
-      COUNT(*) FILTER (WHERE event_type = 'pr') AS prs,
-      COUNT(*) FILTER (WHERE event_type = 'review') AS reviews
-    FROM activity_events e
-    JOIN github_users u ON u.id = e.user_id
-    JOIN repos r ON r.github_repo_id = e.repo_id
-  `;
-
-  activityParamsBase.push(String(orgId).toLowerCase());
-  activityQuery += ` WHERE LOWER(r.owner) = $${activityParamsBase.length} `;
-
-  if (Array.isArray(EXCLUDED_GITHUB_LOGINS) && EXCLUDED_GITHUB_LOGINS.length > 0) {
-    activityParamsBase.push(EXCLUDED_GITHUB_LOGINS.map((l) => String(l).toLowerCase()));
-    activityQuery += ` AND LOWER(u.login) <> ALL($${activityParamsBase.length}) `;
-  }
-
-  activityQuery += ` AND e.created_at BETWEEN $${activityParamsBase.length + 1} AND $${activityParamsBase.length + 2} `;
-
-  activityQuery += `
-    GROUP BY e.user_id;
-  `;
-
-  const currentRes = await db.query(activityQuery, [
-    ...activityParamsBase,
-    start.toISOString(),
-    end.toISOString(),
-  ]);
-
-  const currentMap = {};
-
-  currentRes.rows.forEach((row) => {
-    currentMap[row.user_id] = {
-      commits: Number(row.commits),
-      prs: Number(row.prs),
-      reviews: Number(row.reviews),
-    };
-  });
-
-  /* 3️⃣ Previous period activity */
-  const previousRes = await db.query(activityQuery, [
-    ...activityParamsBase,
-    prevStart.toISOString(),
-    prevEnd.toISOString(),
-  ]);
-
-  const previousMap = {};
-
-  previousRes.rows.forEach((row) => {
-    previousMap[row.user_id] = {
-      commits: Number(row.commits),
-      prs: Number(row.prs),
-      reviews: Number(row.reviews),
-    };
-  });
-
-  /* 4️⃣ Construct final user list */
-  const final = users.map((u) => {
-    const current = currentMap[u.id] || { commits: 0, prs: 0, reviews: 0 };
-    const previous = previousMap[u.id] || { commits: 0, prs: 0, reviews: 0 };
+  const final = assignments.map((row) => {
+    const current = currentMap[row.assignment_id] || { commits: 0, prs: 0, reviews: 0 };
+    const previous = previousMap[row.assignment_id] || { commits: 0, prs: 0, reviews: 0 };
 
     return {
-      login: u.login,
-      name: u.name || null,
-      avatar: u.avatar,
-      role: u.role || null,
-
+      assignment_id: row.assignment_id,
+      login: row.login,
+      name: row.name || null,
+      avatar: row.avatar,
+      role: row.role || null,
+      is_active: Boolean(row.is_active),
+      active_from: row.active_from,
+      active_to: row.active_to,
       commits: current.commits,
       prs: current.prs,
       reviews: current.reviews,
-
       diffCommits: diff(current.commits, previous.commits),
       diffPRs: diff(current.prs, previous.prs),
       diffReviews: diff(current.reviews, previous.reviews),
-
-      total_activity: current.commits + current.prs + current.reviews,
+      total_activity: current.prs + current.reviews,
     };
   });
 
-  /* 5️⃣ Sort by activity */
-  final.sort((a, b) => b.total_activity - a.total_activity);
+  sortUsers(final, sortBy, sortOrder);
 
-  /* 6️⃣ Pagination */
-  const totalUsers = final.length;
+  const term = search ? String(search).trim().toLowerCase() : "";
+  const results = term
+    ? final.filter(
+        (u) =>
+          (u.login || "").toLowerCase().includes(term)
+          || (u.name || "").toLowerCase().includes(term)
+      )
+    : final;
+
+  const totalUsers = results.length;
   const totalPages = Math.ceil(totalUsers / limit);
-
   const startIndex = (page - 1) * limit;
-  const endIndex = startIndex + limit;
-
-  const usersPage = final.slice(startIndex, endIndex);
-
-  /* 7️⃣ Return paginated response */
+  const usersPage = results.slice(startIndex, startIndex + limit);
 
   return {
     users: usersPage,
@@ -189,3 +212,5 @@ const getOrgUsers = async (
 module.exports = {
   getOrgUsers,
 };
+
+

--- a/github-activity-tracker/backend/services/orgUsersService.js
+++ b/github-activity-tracker/backend/services/orgUsersService.js
@@ -62,7 +62,9 @@ const getOrgUsers = async (
     SELECT
       u.id,
       u.login AS login,
-      u.avatar_url AS avatar
+      u.name AS name,
+      u.avatar_url AS avatar,
+      u.role AS role
     FROM github_users u
   `;
 
@@ -145,7 +147,9 @@ const getOrgUsers = async (
 
     return {
       login: u.login,
+      name: u.name || null,
       avatar: u.avatar,
+      role: u.role || null,
 
       commits: current.commits,
       prs: current.prs,

--- a/github-activity-tracker/backend/services/organizationsService.js
+++ b/github-activity-tracker/backend/services/organizationsService.js
@@ -1,0 +1,57 @@
+const pool = require('../db/dbPool');
+const { parseOrganizationsFromEnv } = require('../db/initLookupTables');
+
+async function getAllOrganizations() {
+  const result = await pool.query(
+    'SELECT id, slug, name FROM organizations ORDER BY name ASC'
+  );
+  return result.rows;
+}
+
+async function getOrganizationSlugs() {
+  const organizations = await getAllOrganizations();
+  return organizations.map((organization) => organization.slug);
+}
+
+async function getOrganizationNames() {
+  return getOrganizationSlugs();
+}
+
+function normalizeOrganization(organization) {
+  return String(organization).trim().toLowerCase();
+}
+
+async function isValidOrganization(organization) {
+  if (!organization || typeof organization !== 'string') {
+    return false;
+  }
+
+  const normalized = normalizeOrganization(organization);
+  const result = await pool.query(
+    'SELECT 1 FROM organizations WHERE slug = $1 LIMIT 1',
+    [normalized]
+  );
+  return result.rowCount > 0;
+}
+
+async function getOrganizationIdBySlug(organization) {
+  if (!organization || typeof organization !== 'string') {
+    return null;
+  }
+
+  const result = await pool.query(
+    'SELECT id FROM organizations WHERE slug = $1 LIMIT 1',
+    [normalizeOrganization(organization)]
+  );
+  return result.rows[0]?.id || null;
+}
+
+module.exports = {
+  getAllOrganizations,
+  getOrganizationSlugs,
+  getOrganizationNames,
+  normalizeOrganization,
+  isValidOrganization,
+  getOrganizationIdBySlug,
+  parseOrganizationsFromEnv,
+};

--- a/github-activity-tracker/backend/services/prSyncService.js
+++ b/github-activity-tracker/backend/services/prSyncService.js
@@ -2,6 +2,7 @@ const githubClient = require('../utils/githubClient');
 const pool = require('../db/dbPool');
 const { GITHUB, POSTGRES } = require('../config/errorCodes');
 const { isExcludedGitHubLogin } = require('../config/excludedGitHubLogins');
+const { upsertGitHubUser } = require('./githubUserService');
 
 /**
  * Sync pull requests for a single repository.
@@ -102,23 +103,13 @@ async function syncPRs(repoId) {
             type,
           } = author;
 
-          // Upsert into github_users using github_user_id as unique key
-          const userResult = await pool.query(
-            `
-              INSERT INTO github_users (github_user_id, login, avatar_url, html_url, type)
-              VALUES ($1, $2, $3, $4, $5)
-              ON CONFLICT (github_user_id)
-              DO UPDATE SET
-                login = EXCLUDED.login,
-                avatar_url = EXCLUDED.avatar_url,
-                html_url = EXCLUDED.html_url,
-                type = EXCLUDED.type
-              RETURNING id
-            `,
-            [github_user_id, login, avatar_url || null, html_url || null, type || null]
-          );
-
-          const userId = userResult.rows[0].id;
+          const userId = await upsertGitHubUser({
+            github_user_id,
+            login,
+            avatar_url,
+            html_url,
+            type,
+          });
 
           // Insert event first; only increment prs_count if this PR is new.
           const eventInsert = await pool.query(

--- a/github-activity-tracker/backend/services/reviewSyncService.js
+++ b/github-activity-tracker/backend/services/reviewSyncService.js
@@ -3,6 +3,7 @@ require('dotenv').config();
 const pool = require('../db/dbPool');
 const { POSTGRES } = require('../config/errorCodes');
 const { isExcludedGitHubLogin } = require('../config/excludedGitHubLogins');
+const { upsertGitHubUser } = require('./githubUserService');
 
 const GRAPHQL_URL = 'https://api.github.com/graphql';
 const PR_PAGE_SIZE = 50;
@@ -50,7 +51,7 @@ const QUERY_PR_PAGE = `
               author {
                 __typename
                 login
-                ... on User { databaseId avatarUrl url }
+                ... on User { databaseId avatarUrl url name }
                 ... on Bot { databaseId avatarUrl url }
               }
             }
@@ -74,7 +75,7 @@ const QUERY_PR_REVIEWS_PAGE = `
             author {
               login
               __typename
-              ... on User { databaseId avatarUrl url }
+              ... on User { databaseId avatarUrl url name }
               ... on Bot { databaseId avatarUrl url }
             }
           }
@@ -179,23 +180,16 @@ async function syncReviews(repoId) {
             const avatarUrl = reviewer.avatarUrl || null;
             const htmlUrl = reviewer.url || null;
             const type = reviewer.__typename === 'Bot' ? 'Bot' : 'User';
+            const profileName = reviewer.name || null;
 
-            // Upsert reviewer into github_users
-            const userResult = await pool.query(
-              `
-              INSERT INTO github_users (github_user_id, login, avatar_url, html_url, type)
-              VALUES ($1, $2, $3, $4, $5)
-              ON CONFLICT (github_user_id)
-              DO UPDATE SET
-                login = EXCLUDED.login,
-                avatar_url = EXCLUDED.avatar_url,
-                html_url = EXCLUDED.html_url,
-                type = EXCLUDED.type
-              RETURNING id
-            `,
-              [githubUserId, login, avatarUrl, htmlUrl, type]
-            );
-            const userId = userResult.rows[0].id;
+            const userId = await upsertGitHubUser({
+              github_user_id: githubUserId,
+              login,
+              avatar_url: avatarUrl,
+              html_url: htmlUrl,
+              type,
+              name: profileName,
+            });
 
             // Insert event first; only increment reviews_count if this review is new.
             const eventInsert = await pool.query(

--- a/github-activity-tracker/backend/services/userDetailsService.js
+++ b/github-activity-tracker/backend/services/userDetailsService.js
@@ -1,5 +1,6 @@
 const pool = require('../db/dbPool');
 const { isExcludedGitHubLogin } = require('../config/excludedGitHubLogins');
+const { userDetailsJoinSql } = require('../utils/userRoleSql');
 
 /* -----------------------------------------------
    Helper: Generate continuous UTC calendar-day keys
@@ -26,15 +27,23 @@ function percentChange(current, previous) {
 /* ------------------------------------------------
    MAIN SERVICE
 ------------------------------------------------ */
-async function getUserDetails(orgId, login, period) {
+async function getUserDetails(orgId, login, period, role = null) {
   if (isExcludedGitHubLogin(login)) {
     throw new Error('User not found');
   }
   /* 1. Get user details */
   const userQuery = `
-    SELECT id, login, avatar_url, name, role, NULL as email
-    FROM github_users
-    WHERE login = $1
+    SELECT
+      u.id,
+      u.login,
+      u.avatar_url,
+      u.name,
+      ur.name AS role,
+      NULL AS email
+    FROM github_users u
+    LEFT JOIN user_details ud ON ud.user_id = u.id AND ud.active = true
+    LEFT JOIN user_roles ur ON ur.id = ud.role_id
+    WHERE u.login = $1
   `;
   const userRes = await pool.query(userQuery, [login]);
 
@@ -50,6 +59,7 @@ async function getUserDetails(orgId, login, period) {
     daily: 1,
     weekly: 7,
     monthly: 30,
+    yearly: 365,
   };
 
   const days = periods[period];
@@ -70,30 +80,40 @@ async function getUserDetails(orgId, login, period) {
   prevStart.setUTCDate(prevEnd.getUTCDate() - (days - 1));
   prevStart.setUTCHours(0, 0, 0, 0);
 
+  const orgOwner = String(orgId).toLowerCase();
+
   /* 3. Fetch daily activity for selected range (scoped to org repos) */
-  const dailyQuery = `
+  let dailyQuery = `
     SELECT
       DATE(e.created_at) as date,
       COUNT(*) FILTER (WHERE e.event_type = 'commit') AS commits,
       COUNT(*) FILTER (WHERE e.event_type = 'pr') AS prs,
       COUNT(*) FILTER (WHERE e.event_type = 'review') AS reviews
     FROM activity_events e
+    JOIN github_users u ON u.id = e.user_id
     JOIN repos r ON r.github_repo_id = e.repo_id
+  `;
+
+  const dailyParams = [userId, start.toISOString(), end.toISOString(), orgOwner];
+
+  dailyQuery += userDetailsJoinSql(role ? '$5' : null);
+
+  if (role) {
+    dailyParams.push(role);
+  }
+
+  dailyQuery += `
     WHERE e.user_id = $1
       AND LOWER(r.owner) = $4
       AND e.created_at BETWEEN $2 AND $3
+  `;
+
+  dailyQuery += `
     GROUP BY DATE(e.created_at)
     ORDER BY DATE(e.created_at)
   `;
 
-  const orgOwner = String(orgId).toLowerCase();
-
-  const dailyRes = await pool.query(dailyQuery, [
-    userId,
-    start.toISOString(),
-    end.toISOString(),
-    orgOwner,
-  ]);
+  const dailyRes = await pool.query(dailyQuery, dailyParams);
 
   /* 4. Fill missing days */
   const dateRange = generateDateRange(start, days);
@@ -120,12 +140,11 @@ async function getUserDetails(orgId, login, period) {
   const totalReviews = dailyActivity.reduce((a, b) => a + b.reviews, 0);
 
   /* 6. Fetch previous period totals */
-  const prevRes = await pool.query(dailyQuery, [
-    userId,
-    prevStart.toISOString(),
-    prevEnd.toISOString(),
-    orgOwner,
-  ]);
+  const prevParams = [userId, prevStart.toISOString(), prevEnd.toISOString(), orgOwner];
+  if (role) {
+    prevParams.push(role);
+  }
+  const prevRes = await pool.query(dailyQuery, prevParams);
 
   const prevCommits = prevRes.rows.reduce((a, b) => a + Number(b.commits), 0);
   const prevPRs = prevRes.rows.reduce((a, b) => a + Number(b.prs), 0);

--- a/github-activity-tracker/backend/services/userDetailsService.js
+++ b/github-activity-tracker/backend/services/userDetailsService.js
@@ -32,7 +32,7 @@ async function getUserDetails(orgId, login, period) {
   }
   /* 1. Get user details */
   const userQuery = `
-    SELECT id, login, avatar_url, NULL as name, NULL as email
+    SELECT id, login, avatar_url, name, role, NULL as email
     FROM github_users
     WHERE login = $1
   `;
@@ -175,6 +175,7 @@ async function getUserDetails(orgId, login, period) {
       name: user.name || null,
       email: user.email || null,
       avatar: user.avatar_url,
+      role: user.role || null,
     },
     summary: {
       commits: totalCommits,

--- a/github-activity-tracker/backend/services/userRoleService.js
+++ b/github-activity-tracker/backend/services/userRoleService.js
@@ -1,0 +1,78 @@
+const pool = require('../db/dbPool');
+const { isValidUserRole } = require('../config/userRoles');
+
+async function findUserByLogin(login) {
+  const result = await pool.query(
+    `
+      SELECT id, github_user_id, login, name, role
+      FROM github_users
+      WHERE LOWER(login) = LOWER($1)
+    `,
+    [login]
+  );
+
+  return result.rows[0] || null;
+}
+
+async function getUserRole(login) {
+  const user = await findUserByLogin(login);
+
+  if (!user) {
+    return null;
+  }
+
+  return {
+    user_id: user.id,
+    github_user_id: user.github_user_id,
+    login: user.login,
+    name: user.name || null,
+    role: user.role || null,
+  };
+}
+
+async function setUserRole({ login, role }) {
+  if (!login || typeof login !== 'string') {
+    throw new Error('login is required');
+  }
+
+  if (!role || typeof role !== 'string') {
+    throw new Error('role is required');
+  }
+
+  const trimmedRole = role.trim();
+
+  if (!isValidUserRole(trimmedRole)) {
+    throw new Error('Invalid role value');
+  }
+
+  const user = await findUserByLogin(login);
+
+  if (!user) {
+    return null;
+  }
+
+  const result = await pool.query(
+    `
+      UPDATE github_users
+      SET role = $1, updated_at = CURRENT_TIMESTAMP
+      WHERE id = $2
+      RETURNING id, github_user_id, login, name, role
+    `,
+    [trimmedRole, user.id]
+  );
+
+  const updated = result.rows[0];
+
+  return {
+    user_id: updated.id,
+    github_user_id: updated.github_user_id,
+    login: updated.login,
+    name: updated.name || null,
+    role: updated.role,
+  };
+}
+
+module.exports = {
+  getUserRole,
+  setUserRole,
+};

--- a/github-activity-tracker/backend/services/userRoleService.js
+++ b/github-activity-tracker/backend/services/userRoleService.js
@@ -1,10 +1,15 @@
 const pool = require('../db/dbPool');
-const { isValidUserRole } = require('../config/userRoles');
+const { isValidUserRole, getUserRoleIdByName } = require('./userRolesService');
+const {
+  isValidOrganization,
+  normalizeOrganization,
+  getOrganizationIdBySlug,
+} = require('./organizationsService');
 
 async function findUserByLogin(login) {
   const result = await pool.query(
     `
-      SELECT id, github_user_id, login, name, role
+      SELECT id, github_user_id, login, name
       FROM github_users
       WHERE LOWER(login) = LOWER($1)
     `,
@@ -14,6 +19,17 @@ async function findUserByLogin(login) {
   return result.rows[0] || null;
 }
 
+function formatUserRoleResponse(user, details) {
+  return {
+    user_id: user.id,
+    github_user_id: user.github_user_id,
+    login: user.login,
+    name: user.name || null,
+    role: details?.role || null,
+    organization: details?.organization || null,
+  };
+}
+
 async function getUserRole(login) {
   const user = await findUserByLogin(login);
 
@@ -21,16 +37,54 @@ async function getUserRole(login) {
     return null;
   }
 
-  return {
-    user_id: user.id,
-    github_user_id: user.github_user_id,
-    login: user.login,
-    name: user.name || null,
-    role: user.role || null,
-  };
+  const detailsResult = await pool.query(
+    `
+      SELECT ur.name AS role, o.slug AS organization
+      FROM user_details ud
+      LEFT JOIN user_roles ur ON ur.id = ud.role_id
+      LEFT JOIN organizations o ON o.id = ud.organization_id
+      WHERE ud.user_id = $1 AND ud.active = true
+    `,
+    [user.id]
+  );
+
+  return formatUserRoleResponse(user, detailsResult.rows[0] || null);
 }
 
-async function setUserRole({ login, role }) {
+async function resolveFirstAssignmentActiveFrom(client, userId) {
+  const earliestResult = await client.query(
+    `
+      SELECT MIN(active_from) AS earliest
+      FROM user_details
+      WHERE user_id = $1
+    `,
+    [userId]
+  );
+
+  const activityResult = await client.query(
+    `
+      SELECT MIN(e.created_at) AS earliest
+      FROM activity_events e
+      WHERE e.user_id = $1
+    `,
+    [userId]
+  );
+
+  const candidates = [
+    earliestResult.rows[0]?.earliest,
+    activityResult.rows[0]?.earliest,
+  ].filter(Boolean);
+
+  if (candidates.length === 0) {
+    return new Date();
+  }
+
+  return new Date(
+    Math.min(...candidates.map((value) => new Date(value).getTime()))
+  );
+}
+
+async function setUserRole({ login, role, organization }) {
   if (!login || typeof login !== 'string') {
     throw new Error('login is required');
   }
@@ -39,10 +93,26 @@ async function setUserRole({ login, role }) {
     throw new Error('role is required');
   }
 
+  if (!organization || typeof organization !== 'string') {
+    throw new Error('organization is required');
+  }
+
   const trimmedRole = role.trim();
+  const normalizedOrganization = normalizeOrganization(organization);
 
   if (!isValidUserRole(trimmedRole)) {
     throw new Error('Invalid role value');
+  }
+
+  if (!isValidOrganization(normalizedOrganization)) {
+    throw new Error('Invalid organization value');
+  }
+
+  const roleId = await getUserRoleIdByName(trimmedRole);
+  const organizationId = await getOrganizationIdBySlug(normalizedOrganization);
+
+  if (!roleId || !organizationId) {
+    throw new Error('Invalid role or organization value');
   }
 
   const user = await findUserByLogin(login);
@@ -51,25 +121,93 @@ async function setUserRole({ login, role }) {
     return null;
   }
 
-  const result = await pool.query(
-    `
-      UPDATE github_users
-      SET role = $1, updated_at = CURRENT_TIMESTAMP
-      WHERE id = $2
-      RETURNING id, github_user_id, login, name, role
-    `,
-    [trimmedRole, user.id]
-  );
+  const client = await pool.connect();
 
-  const updated = result.rows[0];
+  try {
+    await client.query('BEGIN');
 
-  return {
-    user_id: updated.id,
-    github_user_id: updated.github_user_id,
-    login: updated.login,
-    name: updated.name || null,
-    role: updated.role,
-  };
+    const activeResult = await client.query(
+      `
+        SELECT id, role_id, organization_id, active_from
+        FROM user_details
+        WHERE user_id = $1 AND active = true
+        ORDER BY active_from DESC, id DESC
+        FOR UPDATE
+      `,
+      [user.id]
+    );
+
+    const activeRows = activeResult.rows;
+    const active = activeRows[0] || null;
+
+    if (
+      active
+      && active.role_id === roleId
+      && active.organization_id === organizationId
+    ) {
+      await client.query('COMMIT');
+      return formatUserRoleResponse(user, {
+        role: trimmedRole,
+        organization: normalizedOrganization,
+      });
+    }
+
+    const roleHistoryResult = await client.query(
+      `
+        SELECT 1
+        FROM user_details
+        WHERE user_id = $1
+          AND role_id IS NOT NULL
+        LIMIT 1
+      `,
+      [user.id]
+    );
+    const hasEverAssignedRole = roleHistoryResult.rowCount > 0;
+    const isFirstAssignment = !hasEverAssignedRole;
+    const activeFrom = isFirstAssignment
+      ? await resolveFirstAssignmentActiveFrom(client, user.id)
+      : new Date();
+
+    if (activeRows.length > 0) {
+      await client.query(
+        `
+          UPDATE user_details
+          SET active = false,
+              active_to = $2,
+              updated_at = CURRENT_TIMESTAMP
+          WHERE user_id = $1
+            AND active = true
+        `,
+        [user.id, activeFrom]
+      );
+    }
+
+    await client.query(
+      `
+        INSERT INTO user_details (
+          user_id,
+          role_id,
+          organization_id,
+          active,
+          active_from,
+          active_to
+        )
+        VALUES ($1, $2, $3, true, $4, NULL)
+      `,
+      [user.id, roleId, organizationId, activeFrom]
+    );
+
+    await client.query('COMMIT');
+    return formatUserRoleResponse(user, {
+      role: trimmedRole,
+      organization: normalizedOrganization,
+    });
+  } catch (error) {
+    await client.query('ROLLBACK');
+    throw error;
+  } finally {
+    client.release();
+  }
 }
 
 module.exports = {

--- a/github-activity-tracker/backend/services/userRolesService.js
+++ b/github-activity-tracker/backend/services/userRolesService.js
@@ -1,0 +1,46 @@
+const pool = require('../db/dbPool');
+const { parseUserRolesFromEnv } = require('../config/defaultUserRoles');
+
+async function getAllUserRoles() {
+  const result = await pool.query(
+    'SELECT id, name FROM user_roles ORDER BY name ASC'
+  );
+  return result.rows;
+}
+
+async function getUserRoleNames() {
+  const roles = await getAllUserRoles();
+  return roles.map((role) => role.name);
+}
+
+async function isValidUserRole(roleName) {
+  if (!roleName || typeof roleName !== 'string') {
+    return false;
+  }
+
+  const trimmed = roleName.trim();
+  const result = await pool.query(
+    'SELECT 1 FROM user_roles WHERE name = $1 LIMIT 1',
+    [trimmed]
+  );
+  return result.rowCount > 0;
+}
+
+async function getUserRoleIdByName(roleName) {
+  if (!roleName || typeof roleName !== 'string') {
+    return null;
+  }
+
+  const result = await pool.query(
+    'SELECT id FROM user_roles WHERE name = $1 LIMIT 1',
+    [roleName.trim()]
+  );
+  return result.rows[0]?.id || null;
+}
+
+module.exports = {
+  getAllUserRoles,
+  getUserRoleNames,
+  isValidUserRole,
+  getUserRoleIdByName,
+};

--- a/github-activity-tracker/backend/utils/userRoleSql.js
+++ b/github-activity-tracker/backend/utils/userRoleSql.js
@@ -1,0 +1,54 @@
+function userAssignmentWindowSql() {
+  return `
+    ud.user_id = u.id
+    AND ud.active = true
+    AND ud.active_from <= e.created_at
+    AND (ud.active_to IS NULL OR e.created_at < ud.active_to)`;
+}
+
+function userDetailsRoleNameMatchSql(roleParam) {
+  return `
+    ud.role_id IS NOT NULL
+    AND EXISTS (
+      SELECT 1
+      FROM user_roles ur_match
+      WHERE ur_match.id = ud.role_id
+        AND ur_match.name = ${roleParam}
+    )`;
+}
+
+function userDetailsExistsSql(roleParam = null) {
+  const roleClause = roleParam
+    ? `AND ${userDetailsRoleNameMatchSql(roleParam)}`
+    : '';
+
+  return `
+    EXISTS (
+      SELECT 1
+      FROM user_details ud
+      WHERE ${userAssignmentWindowSql()}
+        ${roleClause}
+    )`;
+}
+
+function userDetailsJoinSql(roleParam = null) {
+  const roleClause = roleParam
+    ? `AND ${userDetailsRoleNameMatchSql(roleParam)}`
+    : '';
+
+  return `
+    JOIN user_details ud ON ${userAssignmentWindowSql()}
+      ${roleClause}`;
+}
+
+// Used by userDetailsService when scoping a single known user.
+function userDetailsRoleFilterSql(roleParam) {
+  return userDetailsRoleNameMatchSql(roleParam);
+}
+
+module.exports = {
+  userAssignmentWindowSql,
+  userDetailsRoleFilterSql,
+  userDetailsJoinSql,
+  userDetailsExistsSql,
+};

--- a/github-activity-tracker/deploy/gh-tracker-values.yaml
+++ b/github-activity-tracker/deploy/gh-tracker-values.yaml
@@ -6,6 +6,10 @@ ghtrackerservice:
       rds_port: "5432"
       rds_username: "<username>"   # provide username
   secrets:
+    # Rancher/K8s equivalent of backend/.env for lookup seed data.
+    app-config:
+      github_org: mosip,inji
+      user_roles: Developer,Tech Lead,Architect,Product Owner,Leadership,QA Engineer,DevOps Engineer
     rds-secret:
       rds_password: <your_password>    # Provide rds password
     github-token:

--- a/github-activity-tracker/docker-compose.yml
+++ b/github-activity-tracker/docker-compose.yml
@@ -26,6 +26,8 @@ services:
       RDS_USER: ${RDS_USER:-github_user}
       RDS_PASSWORD: ${RDS_PASSWORD:-github_password}
       GITHUB_TOKEN: ${GITHUB_TOKEN}
+      GITHUB_ORG: ${GITHUB_ORG}
+      USER_ROLES: ${USER_ROLES}
       ALLOWED_ORIGINS: ${ALLOWED_ORIGINS:-http://localhost}
       NODE_ENV: production
     depends_on:
@@ -33,6 +35,7 @@ services:
         condition: service_healthy
     ports:
       - "3000:3000"
+    command: ["sh", "-c", "npm run migrate && node app.js"]
     restart: unless-stopped
 
   # Run once per environment:
@@ -46,6 +49,8 @@ services:
       RDS_DATABASE: ${RDS_DATABASE:-github_data}
       RDS_USER: ${RDS_USER:-github_user}
       RDS_PASSWORD: ${RDS_PASSWORD:-github_password}
+      GITHUB_ORG: ${GITHUB_ORG}
+      USER_ROLES: ${USER_ROLES}
       NODE_ENV: production
     depends_on:
       db:

--- a/github-activity-tracker/frontend/.env.example
+++ b/github-activity-tracker/frontend/.env.example
@@ -1,2 +1,1 @@
 VITE_API_BASE_URL=http://localhost:3000
-VITE_ORGANIZATIONS=mosip,inji

--- a/github-activity-tracker/frontend/index.html
+++ b/github-activity-tracker/frontend/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="description" content="GitHub Activity Dashboard for tracking repository commits, pull requests, issues, and reviews" />
+    <meta name="description" content="GitHub Activity Dashboard for tracking pull requests, issues, and reviews" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <title>GitHub Activity Dashboard</title>
   </head>

--- a/github-activity-tracker/frontend/src/App.tsx
+++ b/github-activity-tracker/frontend/src/App.tsx
@@ -7,15 +7,15 @@ import TeamMembers from "./components/TeamMembers";
 import LeaderboardCard from "./components/LeaderboardCard";
 import UserProfile from "./components/UserProfile";
 
-import { DEFAULT_ORG } from "./lib/organizations";
+import { DEFAULT_PERIOD, type PeriodValue } from "./lib/periods";
 import {
   fetchOrgSummary,
   fetchOrgActivity,
   fetchLeaderboard,
+  fetchOrganizations,
 } from "./lib/api";
 
 /* SVG ICON IMPORTS */
-import CommitIcon from "./assets/CommitIcon.svg";
 import PRIcon from "./assets/PRIcon.svg";
 import CodeReviewIcon from "./assets/CodeReviewIcon.svg";
 import TotalActivityIcon from "./assets/TotalActivityIcon.svg";
@@ -27,9 +27,9 @@ function App() {
 
   const [selectedUser, setSelectedUser] = useState<string | null>(null);
 
-  const [selectedOrg, setSelectedOrg] = useState<string>(DEFAULT_ORG);
-  const [period, setPeriod] = useState<"daily" | "weekly" | "monthly">("weekly");
-  const [team, setTeam] = useState("all");
+  const [selectedOrg, setSelectedOrg] = useState<string>("");
+  const [period, setPeriod] = useState<PeriodValue>(DEFAULT_PERIOD);
+  const [role, setRole] = useState("all");
   const [project, setProject] = useState("all");
 
   const [summary, setSummary] = useState<any | null>(null);
@@ -41,14 +41,36 @@ function App() {
   useEffect(() => {
     let cancelled = false;
 
+    async function loadOrganizations() {
+      try {
+        const orgs = await fetchOrganizations();
+        if (!cancelled && orgs.length > 0) {
+          setSelectedOrg((current) => current || orgs[0]!.slug);
+        }
+      } catch (err) {
+        console.error("Error loading organizations:", err);
+      }
+    }
+
+    loadOrganizations();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!selectedOrg) return;
+
+    let cancelled = false;
+
     async function loadDashboard() {
       setDashboardLoading(true);
       setDashboardError(null);
 
       try {
         const [summaryData, activityData] = await Promise.all([
-          fetchOrgSummary(selectedOrg, period),
-          fetchOrgActivity(selectedOrg, period),
+          fetchOrgSummary(selectedOrg, period, role),
+          fetchOrgActivity(selectedOrg, period, role),
         ]);
 
         if (cancelled) return;
@@ -68,9 +90,11 @@ function App() {
     return () => {
       cancelled = true;
     };
-  }, [selectedOrg, period]);
+  }, [selectedOrg, period, role]);
 
   useEffect(() => {
+    if (!selectedOrg) return;
+
     async function loadLeaderboard() {
       try {
         const data = await fetchLeaderboard(selectedOrg, period, 10);
@@ -81,7 +105,6 @@ function App() {
           name: u.login,
           team: "—",
           project: "—",
-          commits: u.commits,
           prs: u.prs,
           reviews: u.reviews,
           total: u.score,
@@ -99,6 +122,7 @@ function App() {
   const handleOrganizationChange = (org: string) => {
     setSelectedOrg(org);
     setProject("all");
+    setRole("all");
   };
 
   const handleSelectUser = (name: string) => {
@@ -117,8 +141,8 @@ function App() {
           onOrganizationChange={handleOrganizationChange}
           period={period}
           onPeriodChange={setPeriod}
-          team={team}
-          onTeamChange={setTeam}
+          role={role}
+          onRoleChange={setRole}
           project={project}
           onProjectChange={setProject}
           onDownloadCSV={() => {}}
@@ -141,14 +165,7 @@ function App() {
 
           {!dashboardLoading && !dashboardError && (
             <>
-              <div className="grid grid-cols-1 md:grid-cols-3 xl:grid-cols-4 gap-6 mb-8">
-                <StatsCard
-                  title="Total Commits"
-                  value={summary?.total_commits ?? 0}
-                  change={summary?.change?.commits}
-                  icon={CommitIcon}
-                />
-
+              <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
                 <StatsCard
                   title="Pull Requests"
                   value={summary?.total_prs ?? 0}
@@ -177,7 +194,7 @@ function App() {
 
               <TeamMembers
                 org={selectedOrg}
-                team={team}
+                role={role}
                 project={project}
                 period={period}
                 onSelectUser={handleSelectUser}

--- a/github-activity-tracker/frontend/src/components/ActivityChart.tsx
+++ b/github-activity-tracker/frontend/src/components/ActivityChart.tsx
@@ -9,6 +9,7 @@ import {
 } from "chart.js";
 import type { ChartOptions } from "chart.js";
 import { Bar } from "react-chartjs-2";
+import { formatPeriodLabel, type PeriodValue } from "../lib/periods";
 
 ChartJS.register(CategoryScale, LinearScale, BarElement, Tooltip, Legend);
 
@@ -85,12 +86,82 @@ const columnHoverPlugin = {
 interface ActivityChartProps {
   data?: {
     labels: string[];
-    commits: number[];
     prs: number[];
     reviews: number[];
   };
-  period: "daily" | "weekly" | "monthly";
+  period: PeriodValue;
   showTitle?: boolean;
+}
+
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
+
+function formatMonthLabel(monthKey: string): string {
+  const [year, month] = monthKey.split("-").map(Number);
+  return new Date(year, month - 1, 1).toLocaleDateString("en-US", {
+    month: "short",
+    year: "numeric",
+  });
+}
+
+function aggregateDailyIntoWeeks(
+  labels: string[],
+  pullRequests: number[],
+  reviews: number[],
+) {
+  const weekLabels: string[] = [];
+  const weekPRs: number[] = [];
+  const weekReviews: number[] = [];
+
+  for (let i = 0; i < labels.length; i += 7) {
+    const weekIndex = Math.floor(i / 7) + 1;
+    weekLabels.push(`Week ${weekIndex}`);
+    weekPRs.push(pullRequests.slice(i, i + 7).reduce((a, b) => a + b, 0));
+    weekReviews.push(reviews.slice(i, i + 7).reduce((a, b) => a + b, 0));
+  }
+
+  return { labels: weekLabels, pullRequests: weekPRs, reviews: weekReviews };
+}
+
+function aggregateDailyIntoMonths(
+  labels: string[],
+  pullRequests: number[],
+  reviews: number[],
+) {
+  const monthLabels: string[] = [];
+  const monthPRs: number[] = [];
+  const monthReviews: number[] = [];
+
+  let currentMonth = "";
+  let prSum = 0;
+  let reviewSum = 0;
+
+  const flush = (monthKey: string) => {
+    monthLabels.push(formatMonthLabel(monthKey));
+    monthPRs.push(prSum);
+    monthReviews.push(reviewSum);
+    prSum = 0;
+    reviewSum = 0;
+  };
+
+  for (let i = 0; i < labels.length; i++) {
+    const monthKey = labels[i].slice(0, 7);
+    if (currentMonth && monthKey !== currentMonth) {
+      flush(currentMonth);
+    }
+    currentMonth = monthKey;
+    prSum += pullRequests[i];
+    reviewSum += reviews[i];
+  }
+
+  if (currentMonth) {
+    flush(currentMonth);
+  }
+
+  return {
+    labels: monthLabels,
+    pullRequests: monthPRs,
+    reviews: monthReviews,
+  };
 }
 
 const ActivityChart: React.FC<ActivityChartProps> = ({
@@ -99,7 +170,6 @@ const ActivityChart: React.FC<ActivityChartProps> = ({
   showTitle = true,
 }) => {
   let labels = data?.labels ?? [];
-  let commits = data?.commits ?? [];
   let pullRequests = data?.prs ?? [];
   let reviews = data?.reviews ?? [];
 
@@ -111,44 +181,30 @@ const ActivityChart: React.FC<ActivityChartProps> = ({
   const isPreAggregatedWeekly =
     labels.length > 0 && labels.every((l) => /^Week\s+\d+$/i.test(l));
 
+  const isPreAggregatedMonthly =
+    labels.length > 0 &&
+    labels.every((l) => !ISO_DATE.test(l));
+
   if (period === "monthly" && labels.length > 0 && !isPreAggregatedWeekly) {
-    const weekLabels: string[] = [];
-    const weekCommits: number[] = [];
-    const weekPRs: number[] = [];
-    const weekReviews: number[] = [];
-
-    for (let i = 0; i < labels.length; i += 7) {
-      const weekIndex = Math.floor(i / 7) + 1;
-
-      weekLabels.push(`Week ${weekIndex}`);
-
-      weekCommits.push(
-        commits.slice(i, i + 7).reduce((a, b) => a + b, 0),
-      );
-
-      weekPRs.push(
-        pullRequests.slice(i, i + 7).reduce((a, b) => a + b, 0),
-      );
-
-      weekReviews.push(
-        reviews.slice(i, i + 7).reduce((a, b) => a + b, 0),
-      );
-    }
-
-    labels = weekLabels;
-    commits = weekCommits;
-    pullRequests = weekPRs;
-    reviews = weekReviews;
+    const aggregated = aggregateDailyIntoWeeks(labels, pullRequests, reviews);
+    labels = aggregated.labels;
+    pullRequests = aggregated.pullRequests;
+    reviews = aggregated.reviews;
   }
 
-  const COLOR_COMMITS = "#3B82F6";
+  if (period === "yearly" && labels.length > 0 && !isPreAggregatedMonthly) {
+    const aggregated = aggregateDailyIntoMonths(labels, pullRequests, reviews);
+    labels = aggregated.labels;
+    pullRequests = aggregated.pullRequests;
+    reviews = aggregated.reviews;
+  }
+
   const COLOR_PULLS = "#10B981";
   const COLOR_REVIEWS = "#F59E0B";
 
   const chartData = {
     labels,
     datasets: [
-      { label: "Commits", data: commits, backgroundColor: COLOR_COMMITS },
       {
         label: "Pull Requests",
         data: pullRequests,
@@ -185,7 +241,6 @@ const ActivityChart: React.FC<ActivityChartProps> = ({
             const label = context.dataset.label;
             const value = context.raw;
 
-            if (label === "Commits") return `Commits : ${value}`;
             if (label === "Pull Requests") return `Pull Requests : ${value}`;
             if (label === "Reviews") return `Reviews : ${value}`;
 
@@ -194,7 +249,6 @@ const ActivityChart: React.FC<ActivityChartProps> = ({
 
           labelTextColor: function (context: any) {
             const label = context.dataset.label;
-            if (label === "Commits") return COLOR_COMMITS;
             if (label === "Pull Requests") return COLOR_PULLS;
             if (label === "Reviews") return COLOR_REVIEWS;
             return "#111";
@@ -220,8 +274,7 @@ const ActivityChart: React.FC<ActivityChartProps> = ({
 
       {showTitle && (
         <h2 className="text-gray-800 text-[18px] mb-4">
-          Activity Overview –{" "}
-          {period.charAt(0).toUpperCase() + period.slice(1)}
+          Activity Overview – {formatPeriodLabel(period)}
         </h2>
       )}
 

--- a/github-activity-tracker/frontend/src/components/ActivityItem.tsx
+++ b/github-activity-tracker/frontend/src/components/ActivityItem.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { GitCommit, GitPullRequest, AlertCircle, MessageSquare, User } from 'lucide-react';
+import { GitPullRequest, AlertCircle, MessageSquare, User } from 'lucide-react';
 import type { ActivityItem } from '../lib/database.types';
 
 interface ActivityItemProps {
@@ -11,7 +11,6 @@ interface ActivityItemProps {
 }
 
 const icons = {
-  commit: GitCommit,
   pull_request: GitPullRequest,
   issue: AlertCircle,
   review: MessageSquare,

--- a/github-activity-tracker/frontend/src/components/ActivityTable.tsx
+++ b/github-activity-tracker/frontend/src/components/ActivityTable.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { GitCommit, GitPullRequest, AlertCircle, MessageSquare, User, Calendar } from 'lucide-react';
+import { GitPullRequest, AlertCircle, MessageSquare, User, Calendar } from 'lucide-react';
 import { format } from 'date-fns';
 import type { ActivityItem } from '../lib/database.types';
 
@@ -8,13 +8,13 @@ interface ActivityTableProps {
 }
 
 const icons = {
-  commit: GitCommit,
   pull_request: GitPullRequest,
   issue: AlertCircle,
   review: MessageSquare,
 };
 
 export function ActivityTable({ activities }: ActivityTableProps) {
+  const visibleActivities = activities.filter((activity) => activity.type !== 'commit');
   console.log('Activities received in UI:', activities);
 
   return (
@@ -47,14 +47,14 @@ export function ActivityTable({ activities }: ActivityTableProps) {
             </tr>
           </thead>
           <tbody className="bg-white divide-y divide-gray-200">
-            {activities.length === 0 ? (
+            {visibleActivities.length === 0 ? (
               <tr>
                 <td colSpan={6} className="px-6 py-4 text-center text-sm text-gray-500">
                   No activities found
                 </td>
               </tr>
             ) : (
-              activities.map((activity, index) => {
+              visibleActivities.map((activity, index) => {
                 const Icon = icons[activity.type];
                 return (
                   <tr key={`${activity.type}-${index}`} className="hover:bg-gray-50">

--- a/github-activity-tracker/frontend/src/components/ActivityTrend.tsx
+++ b/github-activity-tracker/frontend/src/components/ActivityTrend.tsx
@@ -21,7 +21,6 @@ ChartJS.register(
 
 interface TrendPoint {
   date: string;
-  commits: number;
   prs: number;
   reviews: number;
 }
@@ -36,15 +35,6 @@ const ActivityTrend: React.FC<ActivityTrendProps> = ({ data }) => {
   const chartData = {
     labels,
     datasets: [
-      {
-        label: "Commits",
-        data: data.map((d) => d.commits),
-        borderColor: "#3b82f6",
-        backgroundColor: "#3b82f6",
-        tension: 0.4,
-        pointRadius: 4,
-        pointBorderWidth: 2,
-      },
       {
         label: "Pull Requests",
         data: data.map((d) => d.prs),

--- a/github-activity-tracker/frontend/src/components/DetailView.tsx
+++ b/github-activity-tracker/frontend/src/components/DetailView.tsx
@@ -4,7 +4,7 @@ import type { ActivityItem } from '../lib/database.types';
 import Modal from './Modal';
 
 interface DetailViewProps {
-  type: 'commit' | 'pull_request' | 'issue' | 'review' | null;
+  type: 'pull_request' | 'issue' | 'review' | null;
   data: ActivityItem[] | null;
   onClose: () => void;
 }
@@ -22,7 +22,6 @@ const DetailView: React.FC<DetailViewProps> = ({ type, data, onClose }) => {
   }
 
   const typeLabels: Record<NonNullable<DetailViewProps['type']>, string> = {
-    commit: 'Commits',
     pull_request: 'Pull Requests',
     issue: 'Issues',
     review: 'Reviews',

--- a/github-activity-tracker/frontend/src/components/LeaderboardCard.tsx
+++ b/github-activity-tracker/frontend/src/components/LeaderboardCard.tsx
@@ -6,9 +6,9 @@ import BronzeIcon from "../assets/BronzeIcon.svg";
 
 interface Leader {
   name: string;
+  login?: string;
   team: string;
   project: string;
-  commits: number;
   prs: number;
   reviews: number;
   total: number;
@@ -68,7 +68,7 @@ const LeaderboardCard: React.FC<LeaderboardCardProps> = ({ leaders }) => {
                   <h2 className="font-semibold text-lg">{user.name}</h2>
 
                   <p className="text-gray-500 text-sm">
-                    {user.team} • {user.project}
+                    {user.login ? `@${user.login}` : `${user.team} • ${user.project}`}
                   </p>
                 </div>
               </div>
@@ -81,13 +81,6 @@ const LeaderboardCard: React.FC<LeaderboardCardProps> = ({ leaders }) => {
 
             {/* METRICS ROW */}
             <div className="flex mt-4 text-sm pl-10 w-full">
-              <div className="flex justify-between flex-1 pr-10">
-                <span style={{ color: "#4A5565" }}>Commits:</span>
-                <span style={{ color: "#155DFC", fontWeight: 600 }}>
-                  {user.commits}
-                </span>
-              </div>
-
               <div className="flex justify-between flex-1 pr-10">
                 <span style={{ color: "#4A5565" }}>PRs:</span>
                 <span style={{ color: "#00A63E", fontWeight: 600 }}>

--- a/github-activity-tracker/frontend/src/components/TeamMembers.tsx
+++ b/github-activity-tracker/frontend/src/components/TeamMembers.tsx
@@ -1,6 +1,10 @@
 import React, { useEffect, useState } from "react";
+import { ArrowDown, ArrowUp } from "lucide-react";
 import { fetchOrgUsers } from "../lib/api";
+import type { PeriodValue } from "../lib/periods";
 
+type SortField = "prs" | "reviews";
+type SortOrder = "asc" | "desc";
 const UserIcon = () => (
   <div className="w-10 h-10 rounded-full bg-gray-200 flex items-center justify-center text-2xl">
     👤
@@ -9,9 +13,9 @@ const UserIcon = () => (
 
 interface TeamMembersProps {
   org: string;
-  team: string;
+  role: string;
   project: string;
-  period: "daily" | "weekly" | "monthly";
+  period: PeriodValue;
   onSelectUser?: (name: string) => void;
 }
 
@@ -21,25 +25,87 @@ const getDiffColor = (diff: number) => {
   return "#155DFC";
 };
 
+interface SortableHeaderProps {
+  label: string;
+  field: SortField;
+  sortBy: SortField | null;
+  sortOrder: SortOrder;
+  onSort: (field: SortField, order: SortOrder) => void;
+}
+
+const SortableHeader: React.FC<SortableHeaderProps> = ({
+  label,
+  field,
+  sortBy,
+  sortOrder,
+  onSort,
+}) => {
+  const isActive = sortBy === field;
+
+  return (
+    <th className="px-4 py-3 font-semibold text-center">
+      <div className="flex items-center justify-center gap-1">
+        <span>{label}</span>
+        <div className="flex flex-col">
+          <button
+            type="button"
+            onClick={() => onSort(field, "asc")}
+            className={`p-0.5 rounded hover:bg-gray-200 transition ${
+              isActive && sortOrder === "asc"
+                ? "text-blue-600 bg-blue-50"
+                : "text-gray-400"
+            }`}
+            aria-label={`Sort ${label} ascending`}
+          >
+            <ArrowUp size={14} />
+          </button>
+          <button
+            type="button"
+            onClick={() => onSort(field, "desc")}
+            className={`p-0.5 rounded hover:bg-gray-200 transition ${
+              isActive && sortOrder === "desc"
+                ? "text-blue-600 bg-blue-50"
+                : "text-gray-400"
+            }`}
+            aria-label={`Sort ${label} descending`}
+          >
+            <ArrowDown size={14} />
+          </button>
+        </div>
+      </div>
+    </th>
+  );
+};
 const TeamMembers: React.FC<TeamMembersProps> = ({
   org,
-  team,
+  role,
   project,
   period,
   onSelectUser,
 }) => {
   const [members, setMembers] = useState<any[]>([]);
+  const [userSearchTerm, setUserSearchTerm] = useState("");
+  const [appliedSearch, setAppliedSearch] = useState("");
 
   const [page, setPage] = useState(1);
   const [limit, setLimit] = useState(10);
   const [totalUsers, setTotalUsers] = useState(0);
   const [totalPages, setTotalPages] = useState(1);
-
+  const [sortBy, setSortBy] = useState<SortField | null>(null);
+  const [sortOrder, setSortOrder] = useState<SortOrder>("desc");
   useEffect(() => {
     async function loadUsers() {
       try {
-        const data = await fetchOrgUsers(org, period, page, limit);
-
+        const data = await fetchOrgUsers(
+          org,
+          period,
+          page,
+          limit,
+          role,
+          appliedSearch,
+          sortBy,
+          sortOrder,
+        );
         console.log("API RESPONSE:", data);
 
         if (Array.isArray(data)) {
@@ -63,21 +129,27 @@ const TeamMembers: React.FC<TeamMembersProps> = ({
     }
 
     loadUsers();
-  }, [org, period, page, limit]);
-
+  }, [org, period, page, limit, role, appliedSearch, sortBy, sortOrder]);
   useEffect(() => {
     setPage(1);
-  }, [org]);
+  }, [org, role, project]);
 
+  const handleSearch = () => {
+    setPage(1);
+    setAppliedSearch(userSearchTerm.trim());
+  };
+
+  const handleSort = (field: SortField, order: SortOrder) => {
+    setSortBy(field);
+    setSortOrder(order);
+    setPage(1);
+  };
   const filtered = members.filter((m) => {
-    const matchTeam =
-      team === "all" || (m.team || "").toLowerCase() === team.toLowerCase();
-
     const matchProject =
       project === "all" ||
       (m.project || "").toLowerCase() === project.toLowerCase();
 
-    return matchTeam && matchProject;
+    return matchProject;
   });
 
   const startItem = totalUsers === 0 ? 0 : (page - 1) * limit + 1;
@@ -85,33 +157,67 @@ const TeamMembers: React.FC<TeamMembersProps> = ({
 
   return (
     <div className="bg-white p-6 rounded-xl shadow-sm border mb-8 font-arimo">
-      <h2 className="text-xl font-semibold text-gray-900 mb-6">Team Members</h2>
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-6">
+        <h2 className="text-xl font-semibold text-gray-900">Team Members</h2>
+        <div className="flex gap-2 w-full sm:w-auto">
+          <input
+            type="text"
+            placeholder="Search users..."
+            value={userSearchTerm}
+            onChange={(e) => setUserSearchTerm(e.target.value)}
+            onKeyDown={(e) => e.key === "Enter" && handleSearch()}
+            className="flex-1 sm:w-64 border border-gray-300 rounded px-2 py-1 text-sm focus:ring-2 focus:ring-blue-500"
+          />
+          <button
+            type="button"
+            onClick={handleSearch}
+            className="px-4 py-1 text-sm font-medium text-white bg-blue-600 rounded hover:bg-blue-700"
+          >
+            Search
+          </button>
+        </div>
+      </div>
 
       <div className="overflow-x-auto">
-        <table className="w-full">
+        <table className="w-full table-fixed">
+          <colgroup>
+            <col className="w-[45%]" />
+            <col className="w-[25%]" />
+            <col className="w-[15%]" />
+            <col className="w-[15%]" />
+          </colgroup>
           <thead>
             <tr className="text-left text-gray-600 border-b bg-gray-50">
-              <th className="pb-3 font-semibold">Team Member</th>
-              <th className="pb-3 font-semibold">Team</th>
-              <th className="pb-3 font-semibold">Project</th>
-              <th className="pb-3 font-semibold">Role</th>
-              <th className="pb-3 font-semibold">Commits</th>
-              <th className="pb-3 font-semibold">PRs</th>
-              <th className="pb-3 font-semibold">Reviews</th>
+              <th className="px-4 py-3 font-semibold">Team Member</th>
+              <th className="px-4 py-3 font-semibold">Role</th>
+              <SortableHeader
+                label="PRs"
+                field="prs"
+                sortBy={sortBy}
+                sortOrder={sortOrder}
+                onSort={handleSort}
+              />
+              <SortableHeader
+                label="Reviews"
+                field="reviews"
+                sortBy={sortBy}
+                sortOrder={sortOrder}
+                onSort={handleSort}
+              />
             </tr>
           </thead>
 
           <tbody>
             {filtered.map((m, index) => (
               <tr
-                key={m.login ?? index}
+                key={m.assignment_id ?? `${m.login}-${index}`}
                 className="border-b last:border-0 cursor-pointer hover:bg-gray-50 transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600"
                 onClick={() => onSelectUser?.(m.login)}
                 role={onSelectUser ? "button" : undefined}
                 tabIndex={onSelectUser ? 0 : undefined}
                 aria-label={
                   onSelectUser
-                    ? `View profile for ${m.login}`
+                    ? `View profile for ${m.name || m.login}`
                     : undefined
                 }
                 onKeyDown={(e) => {
@@ -122,35 +228,26 @@ const TeamMembers: React.FC<TeamMembersProps> = ({
                   }
                 }}
               >
-                <td className="py-4 flex items-center gap-3">
+                <td className="px-4 py-4">
+                  <div className="flex items-center gap-3">
                   <UserIcon />
-                  <div>
-                    <p className="font-semibold text-gray-900">{m.login}</p>
-                    <p className="text-gray-500 text-sm">{m.email || "—"}</p>
+                    <div className="min-w-0">
+                      <p className="truncate font-semibold text-gray-900">
+                        {m.name || m.login}
+                      </p>
+                      <p className="truncate text-gray-500 text-sm">{m.login}</p>
+                    </div>
                   </div>
                 </td>
 
-                <td className="text-gray-700">{m.team || "—"}</td>
-                <td className="text-gray-700">{m.project || "—"}</td>
-                <td className="text-gray-700">{m.role || "—"}</td>
-
-                <td className="text-center">
-                  <div
-                    className="font-semibold"
-                    style={{ color: getDiffColor(m.diffCommits) }}
-                  >
-                    {m.commits}
-                  </div>
-                  <div
-                    className="text-sm"
-                    style={{ color: getDiffColor(m.diffCommits) }}
-                  >
-                    ({m.diffCommits > 0 ? "+" : ""}
-                    {m.diffCommits})
-                  </div>
+                <td className="px-4 py-4 text-left text-gray-700">
+                  {m.role || "—"}
+                  {m.role && m.is_active === false && (
+                    <span className="ml-2 text-xs text-gray-500">(inactive)</span>
+                  )}
                 </td>
 
-                <td className="text-center">
+                <td className="px-4 py-4 text-center">
                   <div
                     className="font-semibold"
                     style={{ color: getDiffColor(m.diffPRs) }}
@@ -166,7 +263,7 @@ const TeamMembers: React.FC<TeamMembersProps> = ({
                   </div>
                 </td>
 
-                <td className="text-center">
+                <td className="px-4 py-4 text-center">
                   <div
                     className="font-semibold"
                     style={{ color: getDiffColor(m.diffReviews) }}

--- a/github-activity-tracker/frontend/src/components/TopNav.tsx
+++ b/github-activity-tracker/frontend/src/components/TopNav.tsx
@@ -1,19 +1,13 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 
-import { ORGANIZATIONS } from "../lib/organizations";
+import { PERIOD_OPTIONS, type PeriodValue } from "../lib/periods";
+import { fetchUserRoles, fetchOrganizations } from "../lib/api";
+import type { Organization } from "../lib/organizations";
 import DashboardIconWhite from "../assets/DashboardIconWhite.svg";
 import DashboardIconBlack from "../assets/DashboardIconBlack.svg";
 import LeaderboardIconWhite from "../assets/LeaderboardIconWhite.svg";
 import LeaderboardIconBlack from "../assets/LeaderboardIconBlack.svg";
 import DownloadIcon from "../assets/DownloadIcon.svg";
-
-const PERIOD_OPTIONS = [
-  { value: "daily", label: "Daily" },
-  { value: "weekly", label: "Weekly" },
-  { value: "monthly", label: "Monthly" },
-] as const;
-
-type PeriodValue = (typeof PERIOD_OPTIONS)[number]["value"];
 
 interface TopNavProps {
   activePage: "dashboard" | "leaderboard";
@@ -27,8 +21,8 @@ interface TopNavProps {
   organization: string;
   onOrganizationChange: (value: string) => void;
 
-  team: string;
-  onTeamChange: (value: string) => void;
+  role: string;
+  onRoleChange: (value: string) => void;
 
   project: string;
   onProjectChange: (value: string) => void;
@@ -45,13 +39,56 @@ const TopNav: React.FC<TopNavProps> = ({
   onPeriodChange,
   organization,
   onOrganizationChange,
-  team,
-  onTeamChange,
+  role,
+  onRoleChange,
   project,
   onProjectChange,
   onDownloadCSV,
   onDownloadJSON,
 }) => {
+  const [userRoles, setUserRoles] = useState<string[]>([]);
+  const [organizations, setOrganizations] = useState<Organization[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadRoles() {
+      try {
+        const roles = await fetchUserRoles();
+        if (!cancelled) {
+          setUserRoles(roles.map((role) => role.name));
+        }
+      } catch (error) {
+        console.error("Failed to load user roles:", error);
+      }
+    }
+
+    loadRoles();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadOrganizations() {
+      try {
+        const orgs = await fetchOrganizations();
+        if (!cancelled) {
+          setOrganizations(orgs);
+        }
+      } catch (error) {
+        console.error("Failed to load organizations:", error);
+      }
+    }
+
+    loadOrganizations();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
   const tabStyle = (active: boolean) =>
     `px-4 py-2 rounded-lg font-medium transition-all ${
       active
@@ -160,9 +197,9 @@ const TopNav: React.FC<TopNavProps> = ({
               onChange={(e) => onOrganizationChange(e.target.value)}
               className={filterSelectClass}
             >
-              {ORGANIZATIONS.map((org) => (
-                <option key={org.id} value={org.id}>
-                  {org.label}
+              {organizations.map((org) => (
+                <option key={org.id} value={org.slug}>
+                  {org.name}
                 </option>
               ))}
             </select>
@@ -170,21 +207,23 @@ const TopNav: React.FC<TopNavProps> = ({
 
         </div>
 
-        {/* TEAM */}
+        {/* ROLE */}
         <div className="flex flex-col">
           <label className="text-gray-600 text-sm font-medium mb-2">
-            Team
+            Role
           </label>
 
           <select
-            value={team}
-            onChange={(e) => onTeamChange(e.target.value)}
+            value={role}
+            onChange={(e) => onRoleChange(e.target.value)}
             className={filterSelectClass}
           >
-            <option value="all">All Teams</option>
-            <option value="frontend">Frontend Team</option>
-            <option value="backend">Backend Team</option>
-            <option value="devops">DevOps Team</option>
+            <option value="all">All Roles</option>
+            {userRoles.map((userRole) => (
+              <option key={userRole} value={userRole}>
+                {userRole}
+              </option>
+            ))}
           </select>
         </div>
 

--- a/github-activity-tracker/frontend/src/components/UserActivityStats.tsx
+++ b/github-activity-tracker/frontend/src/components/UserActivityStats.tsx
@@ -1,10 +1,9 @@
 import React from 'react';
-import { User, GitCommit, GitPullRequest, MessageSquare } from 'lucide-react';
+import { User, GitPullRequest, MessageSquare } from 'lucide-react';
 import type { ActivityItem } from '../lib/database.types';
 
 interface UserStats {
   name: string;
-  commits: number;
   pullRequests: number;
   reviews: number;
 }
@@ -16,19 +15,17 @@ interface UserActivityStatsProps {
 export function UserActivityStats({ activities }: UserActivityStatsProps) {
   
   const userStats = activities.reduce<Record<string, UserStats>>((acc, activity) => {
+    if (activity.type === 'commit') return acc;
+
     if (!acc[activity.author]) {
       acc[activity.author] = {
         name: activity.author,
-        commits: 0,
         pullRequests: 0,
         reviews: 0,
       };
     }
 
     switch (activity.type) {
-      case 'commit':
-        acc[activity.author].commits++;
-        break;
       case 'pull_request':
         acc[activity.author].pullRequests++;
         break;
@@ -42,8 +39,8 @@ export function UserActivityStats({ activities }: UserActivityStatsProps) {
 
   
   const sortedUsers = Object.values(userStats).sort((a, b) => {
-    const totalA = a.commits + a.pullRequests + a.reviews;
-    const totalB = b.commits + b.pullRequests + b.reviews;
+    const totalA = a.pullRequests + a.reviews;
+    const totalB = b.pullRequests + b.reviews;
     return totalB - totalA;
   });
 
@@ -60,9 +57,6 @@ export function UserActivityStats({ activities }: UserActivityStatsProps) {
                 User
               </th>
               <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                Commits
-              </th>
-              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
                 Pull Requests
               </th>
               <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
@@ -73,7 +67,7 @@ export function UserActivityStats({ activities }: UserActivityStatsProps) {
           <tbody className="bg-white divide-y divide-gray-200">
             {sortedUsers.length === 0 ? (
               <tr>
-                <td colSpan={4} className="px-6 py-4 text-center text-sm text-gray-500">
+                <td colSpan={3} className="px-6 py-4 text-center text-sm text-gray-500">
                   No user activity found
                 </td>
               </tr>
@@ -84,12 +78,6 @@ export function UserActivityStats({ activities }: UserActivityStatsProps) {
                     <div className="flex items-center">
                       <User className="w-5 h-5 text-gray-400 mr-2" />
                       <div className="text-sm font-medium text-gray-900">{user.name}</div>
-                    </div>
-                  </td>
-                  <td className="px-6 py-4 whitespace-nowrap">
-                    <div className="flex items-center">
-                      <GitCommit className="w-4 h-4 text-gray-400 mr-2" />
-                      <span className="text-sm text-gray-900">{user.commits}</span>
                     </div>
                   </td>
                   <td className="px-6 py-4 whitespace-nowrap">

--- a/github-activity-tracker/frontend/src/components/UserActivityTable.tsx
+++ b/github-activity-tracker/frontend/src/components/UserActivityTable.tsx
@@ -3,7 +3,6 @@ import React from "react";
 
 interface Row {
   date: string;
-  commits: number;
   prs: number;
   reviews: number;
   total: number;
@@ -22,7 +21,6 @@ const UserActivityTable: React.FC<Props> = ({ rows }) => {
         <thead>
           <tr className="text-gray-600 border-b">
             <th className="pb-2">Date</th>
-            <th className="pb-2">Commits</th>
             <th className="pb-2">Pull Requests</th>
             <th className="pb-2">Reviews</th>
             <th className="pb-2">Total</th>
@@ -33,7 +31,6 @@ const UserActivityTable: React.FC<Props> = ({ rows }) => {
           {rows.map((r, i) => (
             <tr key={i} className="border-b text-gray-800">
               <td className="py-2">{r.date}</td>
-              <td className="py-2">{r.commits}</td>
               <td className="py-2">{r.prs}</td>
               <td className="py-2">{r.reviews}</td>
               <td className="py-2 font-semibold">{r.total}</td>

--- a/github-activity-tracker/frontend/src/components/UserProfile.tsx
+++ b/github-activity-tracker/frontend/src/components/UserProfile.tsx
@@ -4,8 +4,13 @@ import { StatsCard } from "./StatsCard";
 import ActivityChart from "./ActivityChart";
 import ActivityTrend from "./ActivityTrend";
 import { fetchUserDetails } from "../lib/api";
+import {
+  DEFAULT_PERIOD,
+  formatPeriodLabel,
+  PERIOD_OPTIONS,
+  type PeriodValue,
+} from "../lib/periods";
 
-import CommitIcon from "../assets/CommitIcon.svg";
 import PRIcon from "../assets/PRIcon.svg";
 import CodeReviewIcon from "../assets/CodeReviewIcon.svg";
 import DownloadIcon from "../assets/DownloadIcon.svg";
@@ -18,15 +23,12 @@ interface UserProfileProps {
 
 interface DailyActivityRow {
   date: string;
-  commits: number;
   prs: number;
   reviews: number;
 }
 
 const UserProfile: React.FC<UserProfileProps> = ({ org, userName, onBack }) => {
-  const [period, setPeriod] = useState<"daily" | "weekly" | "monthly">(
-    "weekly",
-  );
+  const [period, setPeriod] = useState<PeriodValue>(DEFAULT_PERIOD);
 
   const [userData, setUserData] = useState<any>(null);
 
@@ -52,17 +54,14 @@ const UserProfile: React.FC<UserProfileProps> = ({ org, userName, onBack }) => {
     project: userData?.project || "Project Alpha",
   };
 
-  const commits = userData?.summary?.commits || 0;
   const prs = userData?.summary?.prs || 0;
   const reviews = userData?.summary?.reviews || 0;
 
-  const changeCommits = userData?.summary?.change?.commits;
   const changePRs = userData?.summary?.change?.prs;
   const changeReviews = userData?.summary?.change?.reviews;
 
   const chartData = {
     labels: userData?.overview?.labels || [],
-    commits: userData?.overview?.commits || [],
     prs: userData?.overview?.prs || [],
     reviews: userData?.overview?.reviews || [],
   };
@@ -98,38 +97,19 @@ const UserProfile: React.FC<UserProfileProps> = ({ org, userName, onBack }) => {
 
         <div className="flex justify-between items-center mt-8">
           <div className="flex items-center gap-4">
-            <button
-              onClick={() => setPeriod("daily")}
-              className={`px-5 py-2 rounded-lg ${
-                period === "daily"
-                  ? "bg-blue-600 text-white"
-                  : "bg-gray-100 text-gray-700"
-              }`}
-            >
-              Daily
-            </button>
-
-            <button
-              onClick={() => setPeriod("weekly")}
-              className={`px-5 py-2 rounded-lg ${
-                period === "weekly"
-                  ? "bg-blue-600 text-white"
-                  : "bg-gray-100 text-gray-700"
-              }`}
-            >
-              Weekly
-            </button>
-
-            <button
-              onClick={() => setPeriod("monthly")}
-              className={`px-5 py-2 rounded-lg ${
-                period === "monthly"
-                  ? "bg-blue-600 text-white"
-                  : "bg-gray-100 text-gray-700"
-              }`}
-            >
-              Monthly
-            </button>
+            {PERIOD_OPTIONS.map(({ value, label }) => (
+              <button
+                key={value}
+                onClick={() => setPeriod(value)}
+                className={`px-5 py-2 rounded-lg ${
+                  period === value
+                    ? "bg-blue-600 text-white"
+                    : "bg-gray-100 text-gray-700"
+                }`}
+              >
+                {label}
+              </button>
+            ))}
           </div>
 
           <div className="flex items-center gap-4">
@@ -148,14 +128,7 @@ const UserProfile: React.FC<UserProfileProps> = ({ org, userName, onBack }) => {
 
       <div className="max-w-7xl mx-auto px-6">
         {/* Stats Cards */}
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-6 my-10">
-          <StatsCard
-            title="Commits"
-            value={commits}
-            change={changeCommits}
-            icon={CommitIcon}
-          />
-
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6 my-10">
           <StatsCard
             title="Pull Requests"
             value={prs}
@@ -174,8 +147,7 @@ const UserProfile: React.FC<UserProfileProps> = ({ org, userName, onBack }) => {
         {/* Activity Chart */}
         <div className="bg-white border rounded-xl p-6 mb-8 shadow-sm">
           <h2 className="text-xl font-semibold mb-4">
-            Activity Overview –{" "}
-            {period.charAt(0).toUpperCase() + period.slice(1)}
+            Activity Overview – {formatPeriodLabel(period)}
           </h2>
 
           <ActivityChart data={chartData} period={period} showTitle={false} />
@@ -186,7 +158,6 @@ const UserProfile: React.FC<UserProfileProps> = ({ org, userName, onBack }) => {
           data={
             userData?.trend?.labels?.map((label: string, i: number) => ({
               date: label,
-              commits: userData.trend.commits[i],
               prs: userData.trend.prs[i],
               reviews: userData.trend.reviews[i],
             })) || []
@@ -201,7 +172,6 @@ const UserProfile: React.FC<UserProfileProps> = ({ org, userName, onBack }) => {
             <thead>
               <tr className="text-left text-gray-600 border-b">
                 <th className="pb-3">Date</th>
-                <th className="pb-3">Commits</th>
                 <th className="pb-3">Pull Requests</th>
                 <th className="pb-3">Reviews</th>
                 <th className="pb-3">Total</th>
@@ -213,10 +183,6 @@ const UserProfile: React.FC<UserProfileProps> = ({ org, userName, onBack }) => {
                 <tr key={idx} className="border-b last:border-0">
                   <td className="py-3">{row.date}</td>
 
-                  <td className="font-medium" style={{ color: "#155DFC" }}>
-                    {row.commits}
-                  </td>
-
                   <td className="font-medium" style={{ color: "#00A63E" }}>
                     {row.prs}
                   </td>
@@ -226,7 +192,7 @@ const UserProfile: React.FC<UserProfileProps> = ({ org, userName, onBack }) => {
                   </td>
 
                   <td className="font-semibold">
-                    {row.commits + row.prs + row.reviews}
+                    {row.prs + row.reviews}
                   </td>
                 </tr>
               ))}

--- a/github-activity-tracker/frontend/src/lib/api.ts
+++ b/github-activity-tracker/frontend/src/lib/api.ts
@@ -1,4 +1,5 @@
 import axios from "axios";
+import type { PeriodValue } from "./periods";
 
 // Production: use relative URLs (nginx proxies /orgs/, /admin/ to backend - no CORS)
 // Development: use direct backend URL
@@ -75,11 +76,37 @@ export const fetchRepositoryStats = async (repositoryId: string) => {
   }
 };
 
+// Fetch tracked GitHub organizations
+export const fetchOrganizations = async (): Promise<
+  Array<{ id: number; slug: string; name: string }>
+> => {
+  try {
+    const response = await axios.get(`${API_BASE_URL}/organizations`);
+    return response.data;
+  } catch (error) {
+    throw new Error("Failed to fetch organizations");
+  }
+};
+
+// Fetch assignable user job roles
+export const fetchUserRoles = async (): Promise<Array<{ id: number; name: string }>> => {
+  try {
+    const response = await axios.get(`${API_BASE_URL}/user-roles`);
+    return response.data;
+  } catch (error) {
+    throw new Error("Failed to fetch user roles");
+  }
+};
+
 // Fetch org-wide activity chart data
-export const fetchOrgActivity = async (orgId: string, period: string) => {
+export const fetchOrgActivity = async (
+  orgId: string,
+  period: string,
+  role: string = "all",
+) => {
   try {
     const response = await axios.get(`${API_BASE_URL}/orgs/${orgId}/activity`, {
-      params: { period },
+      params: { period, role },
     });
     return response.data;
   } catch (error) {
@@ -93,6 +120,10 @@ export const fetchOrgUsers = async (
   period: string,
   page: number = 1,
   limit: number = 20,
+  role: string = "all",
+  search: string = "",
+  sortBy?: "prs" | "reviews" | null,
+  sortOrder: "asc" | "desc" = "desc",
 ) => {
   try {
     const response = await axios.get(`${API_BASE_URL}/orgs/${org}/users`, {
@@ -100,6 +131,9 @@ export const fetchOrgUsers = async (
         period,
         page,
         limit,
+        role,
+        ...(search ? { search } : {}),
+        ...(sortBy ? { sortBy, sortOrder } : {}),
       },
     });
 
@@ -130,10 +164,14 @@ export const fetchLeaderboard = async (
 };
 
 // Fetch organization summary (commits, PRs, reviews)
-export const fetchOrgSummary = async (orgId: string, period: string) => {
+export const fetchOrgSummary = async (
+  orgId: string,
+  period: string,
+  role: string = "all",
+) => {
   try {
     const response = await axios.get(`${API_BASE_URL}/orgs/${orgId}/summary`, {
-      params: { period },
+      params: { period, role },
     });
     return response.data;
   } catch (error) {
@@ -145,7 +183,7 @@ export const fetchOrgSummary = async (orgId: string, period: string) => {
 export const fetchUserDetails = async (
   orgId: string,
   login: string,
-  period: "daily" | "weekly" | "monthly",
+  period: PeriodValue,
 ) => {
   try {
     const response = await axios.get(

--- a/github-activity-tracker/frontend/src/lib/hooks.ts
+++ b/github-activity-tracker/frontend/src/lib/hooks.ts
@@ -63,11 +63,11 @@ export function useGitHubActivity(
         if (signal.aborted) return;
 
         // Map Activity to ActivityItem
-        const mappedActivities: ActivityItem[] = data.map((activity: Activity) => ({
+        const mappedActivities: ActivityItem[] = data
+          .filter((activity: Activity) => activity.type !== 'commit')
+          .map((activity: Activity) => ({
           type:
-            activity.type === 'commit'
-              ? 'commit'
-              : activity.type === 'pull_request'
+            activity.type === 'pull_request'
               ? 'pull_request'
               : activity.type === 'issue'
               ? 'issue'

--- a/github-activity-tracker/frontend/src/lib/organizations.ts
+++ b/github-activity-tracker/frontend/src/lib/organizations.ts
@@ -1,16 +1,5 @@
 export interface Organization {
-  id: string;
-  label: string;
+  id: number;
+  slug: string;
+  name: string;
 }
-
-// Org IDs are read from VITE_ORGANIZATIONS (comma-separated) in frontend/.env.
-// IDs are kept lowercase to match the `owner` column; labels are uppercased for display.
-const organizationsEnv = import.meta.env.VITE_ORGANIZATIONS!;
-
-export const ORGANIZATIONS: Organization[] = organizationsEnv
-  .split(",")
-  .map((id: string) => id.trim().toLowerCase())
-  .filter((id: string) => id.length > 0)
-  .map((id: string) => ({ id, label: id.toUpperCase() }));
-
-export const DEFAULT_ORG: string = ORGANIZATIONS[0]!.id;

--- a/github-activity-tracker/frontend/src/lib/periods.ts
+++ b/github-activity-tracker/frontend/src/lib/periods.ts
@@ -1,0 +1,14 @@
+export const PERIOD_OPTIONS = [
+  { value: "weekly", label: "Week" },
+  { value: "monthly", label: "Month" },
+  { value: "yearly", label: "Year" },
+] as const;
+
+export type PeriodValue = (typeof PERIOD_OPTIONS)[number]["value"];
+
+export const DEFAULT_PERIOD: PeriodValue = "weekly";
+
+export function formatPeriodLabel(period: PeriodValue): string {
+  const match = PERIOD_OPTIONS.find((option) => option.value === period);
+  return match?.label ?? period;
+}

--- a/github-activity-tracker/frontend/src/vite-env.d.ts
+++ b/github-activity-tracker/frontend/src/vite-env.d.ts
@@ -2,7 +2,6 @@
 
 interface ImportMetaEnv {
   readonly VITE_API_BASE_URL?: string;
-  readonly VITE_ORGANIZATIONS: string;
 }
 
 interface ImportMeta {

--- a/github-activity-tracker/helm/gh-tracker-service/templates/_helpers.tpl
+++ b/github-activity-tracker/helm/gh-tracker-service/templates/_helpers.tpl
@@ -35,6 +35,52 @@ Compile all warnings into a single message.
 */}}
 
 {{/*
+Shared backend environment variables for app and migration job.
+*/}}
+{{- define "gh-tracker-service.env" -}}
+- name: RDS_HOST
+  valueFrom:
+    configMapKeyRef:
+      key: rds-host
+      name: rds-config
+- name: RDS_PORT
+  valueFrom:
+    configMapKeyRef:
+      key: rds-port
+      name: rds-config
+- name: RDS_DATABASE
+  valueFrom:
+    configMapKeyRef:
+      key: rds-database
+      name: rds-config
+- name: RDS_USER
+  valueFrom:
+    configMapKeyRef:
+      key: rds-username
+      name: rds-config
+- name: RDS_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      key: rds_password
+      name: rds-secret
+- name: GITHUB_TOKEN
+  valueFrom:
+    secretKeyRef:
+      key: token
+      name: github-token
+- name: GITHUB_ORG
+  valueFrom:
+    secretKeyRef:
+      key: github_org
+      name: app-config
+- name: USER_ROLES
+  valueFrom:
+    secretKeyRef:
+      key: user_roles
+      name: app-config
+{{- end -}}
+
+{{/*
 Return podAnnotations
 */}}
 {{- define "gh-tracker-service.podAnnotations" -}}

--- a/github-activity-tracker/helm/gh-tracker-service/templates/migrate-job.yaml
+++ b/github-activity-tracker/helm/gh-tracker-service/templates/migrate-job.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.migration.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "common.names.fullname" . }}-migrate-{{ .Release.Revision }}
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-5"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: {{ .Values.migration.backoffLimit }}
+  template:
+    metadata:
+      labels: {{- include "common.labels.standard" . | nindent 8 }}
+    spec:
+      restartPolicy: Never
+      serviceAccountName: {{ template "gh-tracker-service.serviceAccountName" . }}
+      {{- include "gh-tracker-service.imagePullSecrets" . | nindent 6 }}
+      containers:
+        - name: migrate
+          image: {{ template "gh-tracker-service.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["npm", "run", "migrate"]
+          env:
+            {{- include "gh-tracker-service.env" . | nindent 12 }}
+          {{- if .Values.migration.resources }}
+          resources: {{- toYaml .Values.migration.resources | nindent 12 }}
+          {{- end }}
+{{- end }}

--- a/github-activity-tracker/helm/gh-tracker-service/values.yaml
+++ b/github-activity-tracker/helm/gh-tracker-service/values.yaml
@@ -244,36 +244,7 @@ updateStrategy:
 ##     value: "bar"
 ##
 extraEnvVars:
-  - name: RDS_HOST
-    valueFrom:
-      configMapKeyRef:
-        key: rds-host
-        name: rds-config
-  - name: RDS_PORT
-    valueFrom:
-      configMapKeyRef:
-        key: rds-port
-        name: rds-config
-  - name: RDS_DATABASE
-    valueFrom:
-      configMapKeyRef:
-        key: rds-database
-        name: rds-config
-  - name: RDS_USER
-    valueFrom:
-      configMapKeyRef:
-        key: rds-username
-        name: rds-config
-  - name: RDS_PASSWORD
-    valueFrom:
-      secretKeyRef:
-        key: rds_password
-        name: rds-secret
-  - name: GITHUB_TOKEN
-    valueFrom:
-      secretKeyRef:
-        key: token
-        name: github-token
+  {{- include "gh-tracker-service.env" . | nindent 2 }}
 
 ## ConfigMap with extra environment variables
 ##
@@ -302,6 +273,17 @@ extraVolumeMounts: []
 ##         containerPort: 1234
 ##
 initContainers: {}
+
+migration:
+  enabled: true
+  backoffLimit: 3
+  resources:
+    limits:
+      cpu: 300m
+      memory: 512Mi
+    requests:
+      cpu: 100m
+      memory: 256Mi
 
 ## Add sidecars to the  pods.
 ## Example:
@@ -450,6 +432,9 @@ ghtrackerservice:
       rds_port: "5432"
       rds_username: "<username>"   # provide username
   secrets:
+    app-config:
+      github_org: <github_org_csv>    # e.g. mosip,inji
+      user_roles: <user_roles_csv>    # e.g. Developer,Tech Lead,QA Engineer
     rds-secret:
       rds_password: <your_password>    # Provide rds password
     github-token:


### PR DESCRIPTION
## Summary
- Bring MOSIP-45245 GitHub Activity Tracker changes into this fork: user display names, role/org assignment history, and admin APIs to fetch/assign roles
- Role-filtered org activity, summary, users, and user-details APIs, including yearly period support
- Frontend wiring for org/role filters, display names, and PR/review-focused dashboards, plus Helm/docker migration startup updates

## Test plan
- [ ] Run backend migrations and confirm `user_roles`, `organizations`, and `user_details` tables are created/seeded from env
- [ ] Call `GET /user-roles` and `GET /organizations` successfully
- [ ] Assign a role via `POST /admin/users/role` and verify `GET /admin/users/:login/role`
- [ ] Verify org activity/summary/users filter by role and support `yearly`
- [ ] Confirm frontend loads orgs/roles from API and shows display names in team/leaderboard views
- [ ] Smoke-test docker-compose / Helm migrate job startup path

EOF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added role-based filtering, user assignment management, search, and sorting for organization members.
  * Added organization and user-role selection populated from the backend.
  * Added yearly reporting across dashboards, leaderboards, activity views, and summaries.
  * Added administrative tools for assigning roles and backfilling GitHub profile names.
  * Added organization and user-role lookup APIs.

* **Bug Fixes**
  * Improved user profile name availability and activity assignment history.
  * Activity views now focus on pull requests and reviews instead of commits.

* **Deployment**
  * Added automatic database initialization and migration support for local and Kubernetes deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->