### PR TITLE
Fix chart publish target repo name in CI workflow.

### DIFF
--- a/.github/workflows/chart-lint-publish.yml
+++ b/.github/workflows/chart-lint-publish.yml
@@ -45,7 +45,7 @@ jobs:
     with:
       CHARTS_DIR: ./github-activity-tracker/helm
       CHARTS_URL: https://mosip.github.io/mosip-helm
-      REPOSITORY: helm
+      REPOSITORY: mosip-helm
       BRANCH: gh-pages
       INCLUDE_ALL_CHARTS: "${{ inputs.INCLUDE_ALL_CHARTS || 'NO' }}"
       IGNORE_CHARTS: "${{ inputs.IGNORE_CHARTS ||'redis' }}"


### PR DESCRIPTION
Use mosip-helm instead of helm so chart-lint-publish clones the existing mosip/mosip-helm repository.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the chart publishing and linting workflow to target the `mosip-helm` repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->