### PR TITLE
MOSIP-45296- Sync the github user name every after 7 days

### DIFF
--- a/github-activity-tracker/backend/config/syncConfig.js
+++ b/github-activity-tracker/backend/config/syncConfig.js
@@ -17,10 +17,14 @@ const NAME_BACKFILL_MAX_BATCH_SIZE = 500;
 /** Delay in ms before retrying a user whose GitHub name could not be resolved. */
 const NAME_FETCH_RETRY_MS = 24 * 60 * 60 * 1000;
 
+/** Interval in ms after which a stored user name is considered stale and should be re-fetched from GitHub. */
+const NAME_REFRESH_INTERVAL_MS = 7 * 24 * 60 * 60 * 1000;
+
 module.exports = {
   DELAY_BETWEEN_REPOS_MS,
   NAME_BACKFILL_BATCH_SIZE,
   NAME_FETCH_DELAY_MS,
   NAME_BACKFILL_MAX_BATCH_SIZE,
   NAME_FETCH_RETRY_MS,
+  NAME_REFRESH_INTERVAL_MS,
 };

--- a/github-activity-tracker/backend/services/githubUserService.js
+++ b/github-activity-tracker/backend/services/githubUserService.js
@@ -5,6 +5,7 @@ const {
   NAME_BACKFILL_BATCH_SIZE,
   NAME_BACKFILL_MAX_BATCH_SIZE,
   NAME_FETCH_RETRY_MS,
+  NAME_REFRESH_INTERVAL_MS,
 } = require('../config/syncConfig');
 
 function sleep(ms) {
@@ -45,7 +46,7 @@ async function fetchGitHubUserName(login) {
 }
 
 /**
- * Resolve display name: use provided value, existing github_users value, or fetch from GitHub.
+ * Resolve display name: use provided value, re-fetch from GitHub if stale, or use stored value.
  */
 async function resolveGitHubUserName({ github_user_id, login, type, name }) {
   const providedName = normalizeDisplayName(name);
@@ -59,7 +60,7 @@ async function resolveGitHubUserName({ github_user_id, login, type, name }) {
 
   const existing = await pool.query(
     `
-      SELECT name
+      SELECT name, updated_at
       FROM github_users
       WHERE github_user_id = $1
     `,
@@ -67,7 +68,14 @@ async function resolveGitHubUserName({ github_user_id, login, type, name }) {
   );
 
   const storedName = normalizeDisplayName(existing.rows[0]?.name);
+  const updatedAt = existing.rows[0]?.updated_at;
+
   if (storedName) {
+    const isStale = updatedAt && (Date.now() - new Date(updatedAt).getTime()) > NAME_REFRESH_INTERVAL_MS;
+    if (isStale) {
+      const freshName = await fetchGitHubUserName(login);
+      return freshName || storedName;
+    }
     return storedName;
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * GitHub display names are now refreshed when stored information becomes outdated.
  * The system continues showing the previously stored name if GitHub cannot provide an updated one, preventing names from disappearing during temporary fetch failures.
  * New names are still retrieved automatically when no stored name is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->