### PR TITLE
MOSIP-45370 Fix PR file changes count in GitHub Activity Tracker

### DIFF
--- a/github-activity-tracker/backend/migrations/010_add_pr_files_changed_columns.sql
+++ b/github-activity-tracker/backend/migrations/010_add_pr_files_changed_columns.sql
@@ -1,0 +1,8 @@
+-- Track file changes per PR event and aggregate per repo/user.
+ALTER TABLE activity_events ADD COLUMN IF NOT EXISTS files_changed INTEGER;
+
+ALTER TABLE repo_users ADD COLUMN IF NOT EXISTS pr_files_changed_total INTEGER DEFAULT 0;
+
+CREATE INDEX IF NOT EXISTS idx_activity_events_pr_files_changed_backfill
+  ON activity_events (repo_id)
+  WHERE event_type = 'pr' AND files_changed IS NULL;

--- a/github-activity-tracker/backend/migrations/010_add_pr_files_changed_columns.sql
+++ b/github-activity-tracker/backend/migrations/010_add_pr_files_changed_columns.sql
@@ -2,7 +2,3 @@
 ALTER TABLE activity_events ADD COLUMN IF NOT EXISTS files_changed INTEGER;
 
 ALTER TABLE repo_users ADD COLUMN IF NOT EXISTS pr_files_changed_total INTEGER DEFAULT 0;
-
-CREATE INDEX IF NOT EXISTS idx_activity_events_pr_files_changed_backfill
-  ON activity_events (repo_id)
-  WHERE event_type = 'pr' AND files_changed IS NULL;

--- a/github-activity-tracker/backend/migrations/011_add_pr_files_changed_backfill_index.sql
+++ b/github-activity-tracker/backend/migrations/011_add_pr_files_changed_backfill_index.sql
@@ -1,0 +1,4 @@
+-- Non-blocking index for PR file-count backfill (must be the only statement in this migration).
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_activity_events_pr_files_changed_backfill
+  ON activity_events (repo_id)
+  WHERE event_type = 'pr' AND files_changed IS NULL;

--- a/github-activity-tracker/backend/services/orgUsersService.js
+++ b/github-activity-tracker/backend/services/orgUsersService.js
@@ -114,6 +114,7 @@ async function fetchAssignmentActivityMap(orgId, role, start, end) {
       ud.id AS assignment_id,
       COUNT(*) FILTER (WHERE e.event_type = 'commit') AS commits,
       COUNT(*) FILTER (WHERE e.event_type = 'pr') AS prs,
+      COALESCE(SUM(e.files_changed) FILTER (WHERE e.event_type = 'pr'), 0) AS pr_files_changed,
       COUNT(*) FILTER (WHERE e.event_type = 'review') AS reviews,
       COUNT(*) FILTER (WHERE e.event_type = 'issue') AS issues
     FROM activity_events e
@@ -148,6 +149,7 @@ async function fetchAssignmentActivityMap(orgId, role, start, end) {
     map[row.assignment_id] = {
       commits: Number(row.commits) || 0,
       prs: Number(row.prs) || 0,
+      pr_files_changed: Number(row.pr_files_changed) || 0,
       reviews: Number(row.reviews) || 0,
       issues: Number(row.issues) || 0,
     };
@@ -175,8 +177,8 @@ const getOrgUsers = async (
   const previousMap = await fetchAssignmentActivityMap(orgId, role, prevStart, prevEnd);
 
   const final = assignments.map((row) => {
-    const current = currentMap[row.assignment_id] || { commits: 0, prs: 0, reviews: 0, issues: 0 };
-    const previous = previousMap[row.assignment_id] || { commits: 0, prs: 0, reviews: 0, issues: 0 };
+    const current = currentMap[row.assignment_id] || { commits: 0, prs: 0, pr_files_changed: 0, reviews: 0, issues: 0 };
+    const previous = previousMap[row.assignment_id] || { commits: 0, prs: 0, pr_files_changed: 0, reviews: 0, issues: 0 };
 
     return {
       assignment_id: row.assignment_id,
@@ -189,6 +191,7 @@ const getOrgUsers = async (
       active_to: row.active_to,
       commits: current.commits,
       prs: current.prs,
+      pr_files_changed: current.pr_files_changed,
       reviews: current.reviews,
       issues: current.issues,
       diffCommits: diff(current.commits, previous.commits),

--- a/github-activity-tracker/backend/services/prSyncService.js
+++ b/github-activity-tracker/backend/services/prSyncService.js
@@ -48,9 +48,14 @@ async function backfillMissingFilesChanged(repoId, owner, name, deps = {}) {
     || ((client, o, n, num) => fetchPRChangedFiles(client, o, n, num));
   const client = deps.githubClient || githubClient;
 
+  const batchSize = 100;
   const { rows } = await db.query(
-    `SELECT event_id, html_url FROM activity_events WHERE repo_id = $1 AND event_type = 'pr' AND files_changed IS NULL`,
-    [repoId]
+    `SELECT event_id, html_url
+     FROM activity_events
+     WHERE repo_id = $1 AND event_type = 'pr' AND files_changed IS NULL
+     ORDER BY event_id
+     LIMIT $2`,
+    [repoId, batchSize]
   );
 
   for (const row of rows) {

--- a/github-activity-tracker/backend/services/prSyncService.js
+++ b/github-activity-tracker/backend/services/prSyncService.js
@@ -3,6 +3,7 @@ const pool = require('../db/dbPool');
 const { GITHUB, POSTGRES } = require('../config/errorCodes');
 const { isExcludedGitHubLogin } = require('../config/excludedGitHubLogins');
 const { upsertGitHubUser } = require('./githubUserService');
+const { parsePullNumberFromUrl, fetchPRChangedFiles } = require('../utils/prFileChanges');
 
 const SEARCH_SYNC_CONFIG = {
   pr: {
@@ -24,6 +25,47 @@ const SEARCH_SYNC_CONFIG = {
     fetchErrorMessage: 'Error fetching issues from GitHub API:',
   },
 };
+
+async function rebuildPrFileChangeTotals(repoId, deps = {}) {
+  const db = deps.pool || pool;
+  await db.query(
+    `UPDATE repo_users ru
+     SET pr_files_changed_total = totals.files_changed
+     FROM (
+       SELECT user_id, COALESCE(SUM(files_changed), 0) AS files_changed
+       FROM activity_events
+       WHERE repo_id = $1 AND event_type = 'pr'
+       GROUP BY user_id
+     ) totals
+     WHERE ru.repo_id = $1 AND ru.user_id = totals.user_id`,
+    [repoId]
+  );
+}
+
+async function backfillMissingFilesChanged(repoId, owner, name, deps = {}) {
+  const db = deps.pool || pool;
+  const fetchFn = deps.fetchPRChangedFiles
+    || ((client, o, n, num) => fetchPRChangedFiles(client, o, n, num));
+  const client = deps.githubClient || githubClient;
+
+  const { rows } = await db.query(
+    `SELECT event_id, html_url FROM activity_events WHERE repo_id = $1 AND event_type = 'pr' AND files_changed IS NULL`,
+    [repoId]
+  );
+
+  for (const row of rows) {
+    const prNumber = parsePullNumberFromUrl(row.html_url);
+    if (!prNumber) continue;
+
+    const filesChanged = await fetchFn(client, owner, name, prNumber);
+    if (filesChanged == null) continue;
+
+    await db.query(
+      `UPDATE activity_events SET files_changed = $1 WHERE event_type = 'pr' AND event_id = $2 AND files_changed IS NULL`,
+      [filesChanged, row.event_id]
+    );
+  }
+}
 
 /**
  * Sync GitHub search items (PRs or issues) for a single repository.
@@ -142,18 +184,41 @@ async function syncSearchItems(repoId, syncKind) {
             userIdCache.set(github_user_id, userId);
           }
 
+          let filesChanged = null;
+          if (syncKind === 'pr' && itemNumber) {
+            const existingEvent = await pool.query(
+              `SELECT files_changed FROM activity_events WHERE event_type = $1 AND event_id = $2`,
+              [eventType, String(itemId)]
+            );
+
+            if (existingEvent.rowCount === 0 || existingEvent.rows[0].files_changed == null) {
+              filesChanged = await fetchPRChangedFiles(githubClient, owner, name, itemNumber);
+            }
+          }
+
           const eventInsert = await pool.query(
             `
-              INSERT INTO activity_events (event_type, event_id, repo_id, user_id, html_url, created_at)
-              VALUES ($1, $2, $3, $4, $5, $6)
+              INSERT INTO activity_events (event_type, event_id, repo_id, user_id, html_url, created_at, files_changed)
+              VALUES ($1, $2, $3, $4, $5, $6, $7)
               ON CONFLICT (event_type, event_id)
               DO NOTHING
               RETURNING id
             `,
-            [eventType, String(itemId), repoId, userId, item.html_url || null, createdAt]
+            [eventType, String(itemId), repoId, userId, item.html_url || null, createdAt, filesChanged]
           );
 
           if (eventInsert.rowCount === 0) {
+            if (syncKind === 'pr' && filesChanged != null) {
+              await pool.query(
+                `
+                  UPDATE activity_events
+                  SET files_changed = $1
+                  WHERE event_type = $2 AND event_id = $3 AND files_changed IS NULL
+                `,
+                [filesChanged, eventType, String(itemId)]
+              );
+            }
+
             await pool.query(
               `
                 INSERT INTO repo_users (repo_id, user_id, first_seen_at, last_seen_at)
@@ -180,18 +245,34 @@ async function syncSearchItems(repoId, syncKind) {
             continue;
           }
 
-          await pool.query(
-            `
-              INSERT INTO repo_users (repo_id, user_id, ${countColumn}, first_seen_at, last_seen_at)
-              VALUES ($1, $2, 1, $3, $3)
-              ON CONFLICT (repo_id, user_id)
-              DO UPDATE SET
-                ${countColumn} = repo_users.${countColumn} + 1,
-                last_seen_at = GREATEST(repo_users.last_seen_at, EXCLUDED.last_seen_at),
-                first_seen_at = LEAST(COALESCE(repo_users.first_seen_at, EXCLUDED.first_seen_at), EXCLUDED.first_seen_at)
-            `,
-            [repoId, userId, createdAt]
-          );
+          if (syncKind === 'pr') {
+            await pool.query(
+              `
+                INSERT INTO repo_users (repo_id, user_id, ${countColumn}, pr_files_changed_total, first_seen_at, last_seen_at)
+                VALUES ($1, $2, 1, $3, $4, $4)
+                ON CONFLICT (repo_id, user_id)
+                DO UPDATE SET
+                  ${countColumn} = repo_users.${countColumn} + 1,
+                  pr_files_changed_total = COALESCE(repo_users.pr_files_changed_total, 0) + $3,
+                  last_seen_at = GREATEST(repo_users.last_seen_at, EXCLUDED.last_seen_at),
+                  first_seen_at = LEAST(COALESCE(repo_users.first_seen_at, EXCLUDED.first_seen_at), EXCLUDED.first_seen_at)
+              `,
+              [repoId, userId, filesChanged ?? 0, createdAt]
+            );
+          } else {
+            await pool.query(
+              `
+                INSERT INTO repo_users (repo_id, user_id, ${countColumn}, first_seen_at, last_seen_at)
+                VALUES ($1, $2, 1, $3, $3)
+                ON CONFLICT (repo_id, user_id)
+                DO UPDATE SET
+                  ${countColumn} = repo_users.${countColumn} + 1,
+                  last_seen_at = GREATEST(repo_users.last_seen_at, EXCLUDED.last_seen_at),
+                  first_seen_at = LEAST(COALESCE(repo_users.first_seen_at, EXCLUDED.first_seen_at), EXCLUDED.first_seen_at)
+              `,
+              [repoId, userId, createdAt]
+            );
+          }
 
           totalProcessed += 1;
         } catch (itemError) {
@@ -233,6 +314,11 @@ async function syncSearchItems(repoId, syncKind) {
     }
   }
 
+  if (syncKind === 'pr') {
+    await backfillMissingFilesChanged(repoId, owner, name);
+    await rebuildPrFileChangeTotals(repoId);
+  }
+
   if (hadProcessingErrors || hitSearchCap) {
     throw new Error(incompleteMessage);
   }
@@ -245,16 +331,10 @@ async function syncSearchItems(repoId, syncKind) {
   return totalProcessed;
 }
 
-/**
- * Sync pull requests for a single repository.
- */
 async function syncPRs(repoId) {
   return syncSearchItems(repoId, 'pr');
 }
 
-/**
- * Sync GitHub issues for a single repository.
- */
 async function syncIssues(repoId) {
   return syncSearchItems(repoId, 'issue');
 }
@@ -262,4 +342,6 @@ async function syncIssues(repoId) {
 module.exports = {
   syncPRs,
   syncIssues,
+  backfillMissingFilesChanged,
+  rebuildPrFileChangeTotals,
 };

--- a/github-activity-tracker/backend/services/userDetailsService.js
+++ b/github-activity-tracker/backend/services/userDetailsService.js
@@ -67,6 +67,7 @@ async function getUserDetails(orgId, login, period, role = null) {
       DATE(e.created_at) as date,
       COUNT(*) FILTER (WHERE e.event_type = 'commit') AS commits,
       COUNT(*) FILTER (WHERE e.event_type = 'pr') AS prs,
+      COALESCE(SUM(e.files_changed) FILTER (WHERE e.event_type = 'pr'), 0) AS pr_files_changed,
       COUNT(*) FILTER (WHERE e.event_type = 'review') AS reviews,
       COUNT(*) FILTER (WHERE e.event_type = 'issue') AS issues
     FROM activity_events e
@@ -107,11 +108,12 @@ async function getUserDetails(orgId, login, period, role = null) {
   });
 
   const dailyActivity = dateRange.map(date => {
-    const row = dailyMap[date] || { commits: 0, prs: 0, reviews: 0, issues: 0 };
+    const row = dailyMap[date] || { commits: 0, prs: 0, pr_files_changed: 0, reviews: 0, issues: 0 };
     return {
       date,
       commits: Number(row.commits) || 0,
       prs: Number(row.prs) || 0,
+      pr_files_changed: Number(row.pr_files_changed) || 0,
       reviews: Number(row.reviews) || 0,
       issues: Number(row.issues) || 0,
       total: (Number(row.commits) || 0) + (Number(row.prs) || 0) + (Number(row.reviews) || 0) + (Number(row.issues) || 0),

--- a/github-activity-tracker/backend/utils/prFileChanges.js
+++ b/github-activity-tracker/backend/utils/prFileChanges.js
@@ -1,0 +1,23 @@
+function parsePullNumberFromUrl(htmlUrl) {
+  if (!htmlUrl) return null;
+  const match = String(htmlUrl).match(/\/pull\/(\d+)(?:[/?#]|$)/);
+  if (!match) return null;
+  const prNumber = Number.parseInt(match[1], 10);
+  return Number.isFinite(prNumber) ? prNumber : null;
+}
+
+async function fetchPRChangedFiles(githubClient, owner, name, prNumber) {
+  try {
+    const response = await githubClient.get(`/repos/${owner}/${name}/pulls/${prNumber}`);
+    const changedFiles = Number(response.data?.changed_files);
+    return Number.isFinite(changedFiles) ? changedFiles : null;
+  } catch (err) {
+    console.error(`Error fetching PR #${prNumber} file changes:`, err.message);
+    return null;
+  }
+}
+
+module.exports = {
+  parsePullNumberFromUrl,
+  fetchPRChangedFiles,
+};

--- a/github-activity-tracker/backend/utils/prFileChanges.js
+++ b/github-activity-tracker/backend/utils/prFileChanges.js
@@ -9,8 +9,10 @@ function parsePullNumberFromUrl(htmlUrl) {
 async function fetchPRChangedFiles(githubClient, owner, name, prNumber) {
   try {
     const response = await githubClient.get(`/repos/${owner}/${name}/pulls/${prNumber}`);
-    const changedFiles = Number(response.data?.changed_files);
-    return Number.isFinite(changedFiles) ? changedFiles : null;
+    const changedFiles = response.data?.changed_files;
+    return Number.isInteger(changedFiles) && changedFiles >= 0
+      ? changedFiles
+      : null;
   } catch (err) {
     console.error(`Error fetching PR #${prNumber} file changes:`, err.message);
     return null;

--- a/github-activity-tracker/frontend/src/components/TeamMembers.tsx
+++ b/github-activity-tracker/frontend/src/components/TeamMembers.tsx
@@ -170,8 +170,9 @@ const TeamMembers: React.FC<TeamMembersProps> = ({
       <div className="overflow-x-auto">
         <table className="w-full table-fixed">
           <colgroup>
-            <col className="w-[35%]" />
-            <col className="w-[20%]" />
+            <col className="w-[25%]" />
+            <col className="w-[15%]" />
+            <col className="w-[15%]" />
             <col className="w-[15%]" />
             <col className="w-[15%]" />
             <col className="w-[15%]" />
@@ -187,6 +188,7 @@ const TeamMembers: React.FC<TeamMembersProps> = ({
                 sortOrder={sortOrder}
                 onSort={handleSort}
               />
+              <th className="px-4 py-3 font-semibold text-center">File Changes</th>
               <SortableHeader
                 label="Reviews"
                 field="reviews"
@@ -258,6 +260,10 @@ const TeamMembers: React.FC<TeamMembersProps> = ({
                     ({m.diffPRs > 0 ? "+" : ""}
                     {m.diffPRs})
                   </div>
+                </td>
+
+                <td className="px-4 py-4 text-center font-semibold text-gray-900">
+                  {m.pr_files_changed ?? 0}
                 </td>
 
                 <td className="px-4 py-4 text-center">

--- a/github-activity-tracker/frontend/src/components/UserProfile.tsx
+++ b/github-activity-tracker/frontend/src/components/UserProfile.tsx
@@ -25,6 +25,7 @@ interface UserProfileProps {
 interface DailyActivityRow {
   date: string;
   prs: number;
+  pr_files_changed: number;
   reviews: number;
   issues: number;
 }
@@ -193,6 +194,7 @@ const UserProfile: React.FC<UserProfileProps> = ({ org, userName, onBack }) => {
               <tr className="text-left text-gray-600 border-b">
                 <th className="pb-3">Date</th>
                 <th className="pb-3">Pull Requests</th>
+                <th className="pb-3">File Changes</th>
                 <th className="pb-3">Reviews</th>
                 <th className="pb-3">Issues</th>
                 <th className="pb-3">Total</th>
@@ -206,6 +208,10 @@ const UserProfile: React.FC<UserProfileProps> = ({ org, userName, onBack }) => {
 
                   <td className="font-medium" style={{ color: "#00A63E" }}>
                     {row.prs}
+                  </td>
+
+                  <td className="font-medium text-gray-900">
+                    {row.pr_files_changed ?? 0}
                   </td>
 
                   <td className="font-medium" style={{ color: "#F54900" }}>


### PR DESCRIPTION
## Summary
- Add `files_changed` tracking per PR event during sync, with backfill for existing PRs that had NULL values
- Rebuild `pr_files_changed_total` aggregates after backfill to keep repo-user totals consistent
- Add partial index to speed up NULL file-count backfill queries
- Expose `pr_files_changed` in org users API and user details daily activity
- Add File Changes column to Team Members and User Profile views

## Test plan
- [ ] Run migration: `npm run migrate` (or `docker compose run --rm migrate`)
- [ ] Trigger PR sync: `curl -X POST http://localhost:3000/admin/sync/prs`
- [ ] Verify Team Members table shows correct File Changes count per user
- [ ] Verify User Profile daily activity shows File Changes aligned with PR count


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added File Changes metrics to team member summaries and detailed user activity views.
  * Pull request activity now tracks the number of files changed.
  * Existing pull request records are updated when file-change counts become available.
  * Missing values display as zero for consistent reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->