### PR TITLE
Address CodeRabbit review on #70: pin kattu ref, least-privilege permissions

### DIFF
--- a/.github/workflows/push-trigger.yml
+++ b/.github/workflows/push-trigger.yml
@@ -72,6 +72,8 @@ jobs:
   # BUILD_ARTIFACT / needs: here — docker-build.yml just runs
   # `docker buildx build` directly against SERVICE_LOCATION.
   build-dockers-nexus:
+    permissions:
+      contents: read
     strategy:
       matrix:
         include:
@@ -81,7 +83,10 @@ jobs:
             SERVICE_NAME: 'nexus-ui'
       fail-fast: false
     name: ${{ matrix.SERVICE_NAME }}
-    uses: mosip/kattu/.github/workflows/docker-build.yml@master-java21
+    # Pinned to the master-java21 commit reviewed for this change (verified
+    # identical to the branch head at pin time) rather than the movable ref,
+    # per CodeRabbit review on PR #70.
+    uses: mosip/kattu/.github/workflows/docker-build.yml@caba29445fcefaec964b9ef7b44a4f8c667dbb0c
     with:
       SERVICE_LOCATION: ${{ matrix.SERVICE_LOCATION }}
       SERVICE_NAME: ${{ matrix.SERVICE_NAME }}


### PR DESCRIPTION
Replaces #71 — same change, DCO fix. #71's commit was missing the
\`Signed-off-by:\` trailer and its DCO check failed; force-push is disabled
on that branch, so this is a fresh branch with the same commit cherry-picked
with \`--signoff\` instead of an amend.

## Summary
1. **Pin reusable workflow ref** — \`mosip/kattu/.github/workflows/docker-build.yml\` was referenced via the movable \`@master-java21\` branch ref; pinned to the exact commit SHA (\`caba2944\`), verified byte-identical to the branch head at pin time.
2. **Least-privilege permissions** — added \`permissions: {contents: read}\` at the job level. The reusable workflow only needs checkout + Docker Hub auth via secrets (not \`GITHUB_TOKEN\`), so no broader scope is needed.

Targets \`mosip-nexus-docker-build\` (not \`develop\`) — this is a fixup for #70, merge this first so #70 picks it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A5KE4fZxHqbeiDaUJenSfU