### PR TITLE
Address CodeRabbit review on #75 (18 findings) + 1 CodeQL finding

### DIFF
--- a/.github/workflows/mosip-nexus-chart-lint-publish.yml
+++ b/.github/workflows/mosip-nexus-chart-lint-publish.yml
@@ -18,7 +18,7 @@ on:
         description: 'Chart publishing to gh-pages branch'
         required: false
         default: 'NO'
-        type: string
+        type: choice
         options:
           - YES
           - NO
@@ -26,7 +26,7 @@ on:
         description: 'Include all charts for Linting/Publishing (YES/NO)'
         required: false
         default: 'NO'
-        type: string
+        type: choice
         options:
           - YES
           - NO
@@ -43,7 +43,9 @@ jobs:
   # subfolders (mirrors github-activity-tracker/helm/{gh-tracker-ui,gh-tracker-service})
   # so one CHARTS_DIR covers both.
   chart-lint-publish:
-    uses: mosip/kattu/.github/workflows/chart-lint-publish.yml@master
+    permissions:
+      contents: read
+    uses: mosip/kattu/.github/workflows/chart-lint-publish.yml@4e9370bc8edcdada050ccac663a9c751af7ec0aa
     with:
       CHARTS_DIR: ./MosipNexus/helm
       CHARTS_URL: https://mosip.github.io/mosip-helm
@@ -52,10 +54,10 @@ jobs:
       INCLUDE_ALL_CHARTS: "${{ inputs.INCLUDE_ALL_CHARTS || 'NO' }}"
       IGNORE_CHARTS: "${{ inputs.IGNORE_CHARTS || '' }}"
       CHART_PUBLISH: "${{ inputs.CHART_PUBLISH || 'YES' }}"
-      LINTING_CHART_SCHEMA_YAML_URL: "https://raw.githubusercontent.com/mosip/kattu/master/.github/helm-lint-configs/chart-schema.yaml"
-      LINTING_LINTCONF_YAML_URL: "https://raw.githubusercontent.com/mosip/kattu/master/.github/helm-lint-configs/lintconf.yaml"
-      LINTING_CHART_TESTING_CONFIG_YAML_URL: "https://raw.githubusercontent.com/mosip/kattu/master/.github/helm-lint-configs/chart-testing-config.yaml"
-      LINTING_HEALTH_CHECK_SCHEMA_YAML_URL: "https://raw.githubusercontent.com/mosip/kattu/master/.github/helm-lint-configs/health-check-schema.yaml"
+      LINTING_CHART_SCHEMA_YAML_URL: "https://raw.githubusercontent.com/mosip/kattu/4e9370bc8edcdada050ccac663a9c751af7ec0aa/.github/helm-lint-configs/chart-schema.yaml"
+      LINTING_LINTCONF_YAML_URL: "https://raw.githubusercontent.com/mosip/kattu/4e9370bc8edcdada050ccac663a9c751af7ec0aa/.github/helm-lint-configs/lintconf.yaml"
+      LINTING_CHART_TESTING_CONFIG_YAML_URL: "https://raw.githubusercontent.com/mosip/kattu/4e9370bc8edcdada050ccac663a9c751af7ec0aa/.github/helm-lint-configs/chart-testing-config.yaml"
+      LINTING_HEALTH_CHECK_SCHEMA_YAML_URL: "https://raw.githubusercontent.com/mosip/kattu/4e9370bc8edcdada050ccac663a9c751af7ec0aa/.github/helm-lint-configs/health-check-schema.yaml"
     secrets:
       TOKEN: ${{ secrets.ACTION_PAT }}
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}

--- a/MosipNexus/AGENTS.md
+++ b/MosipNexus/AGENTS.md
@@ -14,7 +14,7 @@ gives white-label BYOK chat with no RAG/vector KB.
 
 ## Repo layout
 
-```
+```text
 MosipNexus/
 ├── Server/   # Python 3.13 FastAPI backend — RAG, crawlers, DB, MCP
 │             # → Server/AGENTS.md

--- a/MosipNexus/Server/AGENTS.md
+++ b/MosipNexus/Server/AGENTS.md
@@ -62,6 +62,10 @@ or a white-label `generic` profile by product selection, not by forking code.
 
 ## Running
 
+Prerequisite: copy `.env.example` to `.env`, set `PG_CONNECTION`, and make
+sure Postgres 16 with pgvector is reachable — `run.sh`/`run.bat` only handle
+the Python `.venv`, not the database.
+
 ```bash
 ./run.sh          # Linux/macOS — creates .venv, syncs deps, serves :8010
 run.bat           # Windows
@@ -85,11 +89,14 @@ uv run python -m unittest discover tests
 # or: pytest tests/  (if pytest installed)
 ```
 
-No CI workflow is configured — run this locally before handing off work.
+No CI runs the Server test suite — run this locally before handing off work.
+(CI does exist for Docker builds and Helm chart lint/publish, at the parent
+`mosip-labs` repo root — see the root `AGENTS.md`. It doesn't cover tests.)
 
 ## Conventions
 
 - Google-style docstrings on public functions, e.g.:
+
   ```python
   def retrieve(query: str, k: int = 8) -> tuple[list[Document], str]:
       """Search collections and return documents plus confidence.
@@ -102,6 +109,7 @@ No CI workflow is configured — run this locally before handing off work.
           (documents, confidence) where confidence is high|medium|low.
       """
   ```
+
 - Dependency source of truth is `pyproject.toml` (+ `uv.lock`); `requirements.txt`
   is a generated mirror for `pip install -r`. Keep them in sync if you add a dep.
 - No linter/formatter config is checked in — match existing style.

--- a/MosipNexus/Server/k8s/06-cronjob.yaml
+++ b/MosipNexus/Server/k8s/06-cronjob.yaml
@@ -50,7 +50,10 @@ spec:
               # Pin to a semver tag — never use :latest in production.
               image: nexus-server:v1.0.0
               imagePullPolicy: IfNotPresent
-              command:
+              # args (not command!) — command overrides the image's ENTRYPOINT
+              # (entrypoint.sh), skipping the Alembic migration step it runs.
+              # args only overrides CMD, so entrypoint.sh still runs first.
+              args:
                 - uv
                 - run
                 - python

--- a/MosipNexus/Server/k8s/07-initial-ingest-job.yaml
+++ b/MosipNexus/Server/k8s/07-initial-ingest-job.yaml
@@ -22,9 +22,12 @@
 #   kubectl delete job nexus-initial-ingest -n mosip-nexus
 #   kubectl apply  -f Server/k8s/07-initial-ingest-job.yaml
 #
-# The pg_restore below uses --clean --if-exists, so this is safe to re-run
-# even if nexus-postgres's PVC already has data on it from a prior run of
-# this same job (this job doesn't create or delete that PVC itself).
+# The pg_restore below uses --clean --if-exists, so re-running this Job won't
+# error even if nexus-postgres's PVC already has data on it. That is NOT the
+# same as consequence-free: --clean discards any data added since the
+# snapshot, and running it while nexus-api serves traffic can cause request
+# failures mid-restore. Stop traffic and take a fresh backup first if you're
+# deliberately re-running this — don't treat it as routine.
 
 apiVersion: batch/v1
 kind: Job
@@ -141,10 +144,12 @@ spec:
               gunzip /vectors/nexus_vectors.dump.gz
 
               echo "Restoring into nexus-postgres (this takes ~5–10 minutes)..."
-              # --clean --if-exists makes this idempotent: safe whether postgres-data
-              # is a fresh empty PVC or already has a prior restore on it (e.g. after
-              # deleting and re-applying this Job — 01-postgres.yaml's PVC isn't
-              # deleted along with it).
+              # --clean --if-exists makes this idempotent (won't error) whether
+              # postgres-data is empty or already has a prior restore on it. It is
+              # NOT consequence-free: --clean discards any data added since the
+              # snapshot, and running this while nexus-api serves traffic can cause
+              # request failures mid-restore. Stop traffic and take a fresh backup
+              # first if re-running deliberately, don't rely on this for routine ops.
               PGPASSWORD=$POSTGRES_PASSWORD pg_restore \
                 -h nexus-postgres \
                 -U mosip \

--- a/MosipNexus/UI/AGENTS.md
+++ b/MosipNexus/UI/AGENTS.md
@@ -43,15 +43,19 @@ Node **≥ 20** required. Vite proxies `/api` → `VITE_DEV_API_PROXY` (default
 
 There is no test suite for the UI. `npm run build` (`tsc --noEmit` + `vite
 build`) is the closest correctness signal — run it before handing off work.
-No CI workflow is configured in this repo.
+No CI runs the UI build/typecheck. (CI does exist for Docker builds and Helm
+chart lint/publish, at the parent `mosip-labs` repo root — see the root
+`AGENTS.md`. It doesn't cover this.)
 
 ## Conventions
 
 - JSDoc on exported symbols, e.g.:
+
   ```ts
   /** POST /chat — full RAG answer for one user question. */
   export async function chat(params: {...}): Promise<ChatResponse>
   ```
+
 - Function components + hooks; `ErrorBoundary` is the only class component
   (React requires this for error boundaries).
 - `package.json` is the dependency source of truth; `package-lock.json` locks

--- a/MosipNexus/deploy/nexus-server/delete.sh
+++ b/MosipNexus/deploy/nexus-server/delete.sh
@@ -16,8 +16,8 @@ NS=mosip-nexus
 RELEASE=nexus-server
 
 function deleting_nexus_server() {
-  read -p "Are you sure you want to delete the $RELEASE helm release in namespace $NS? (Y/n) " yn
-  if [ "$yn" = "Y" ] ; then
+  IFS= read -r -p "Are you sure you want to delete the $RELEASE helm release in namespace $NS? (y/N) " yn
+  if [[ "$yn" =~ ^[Yy]$ ]] ; then
     helm -n "$NS" delete "$RELEASE"
   else
     echo "Aborted."

--- a/MosipNexus/deploy/nexus-server/install.sh
+++ b/MosipNexus/deploy/nexus-server/install.sh
@@ -24,7 +24,7 @@ function installing_nexus_server() {
   echo "Installing/upgrading $RELEASE from $CHART_DIR"
   helm -n "$NS" upgrade --install "$RELEASE" "$CHART_DIR" "${VALUES_ARGS[@]}" --wait
 
-  kubectl -n "$NS" get deploy -o name | xargs -r -n1 -t kubectl -n "$NS" rollout status
+  kubectl -n "$NS" rollout status deployment/nexus-api
   echo "Installed $RELEASE"
   return 0
 }

--- a/MosipNexus/deploy/nexus-ui/delete.sh
+++ b/MosipNexus/deploy/nexus-ui/delete.sh
@@ -13,8 +13,8 @@ NS=mosip-nexus
 RELEASE=nexus-ui
 
 function deleting_nexus_ui() {
-  read -p "Are you sure you want to delete the $RELEASE helm release in namespace $NS? (Y/n) " yn
-  if [ "$yn" = "Y" ] ; then
+  IFS= read -r -p "Are you sure you want to delete the $RELEASE helm release in namespace $NS? (y/N) " yn
+  if [[ "$yn" =~ ^[Yy]$ ]] ; then
     helm -n "$NS" delete "$RELEASE"
   else
     echo "Aborted."

--- a/MosipNexus/deploy/nexus-ui/install.sh
+++ b/MosipNexus/deploy/nexus-ui/install.sh
@@ -30,7 +30,7 @@ function installing_nexus_ui() {
   echo "Installing/upgrading $RELEASE from $CHART_DIR"
   helm -n "$NS" upgrade --install "$RELEASE" "$CHART_DIR" "${VALUES_ARGS[@]}" --wait
 
-  kubectl -n "$NS" get deploy -o name | xargs -r -n1 -t kubectl -n "$NS" rollout status
+  kubectl -n "$NS" rollout status deployment/nexus-ui
   echo "Installed $RELEASE"
   return 0
 }

--- a/MosipNexus/helm/nexus-server/.helmignore
+++ b/MosipNexus/helm/nexus-server/.helmignore
@@ -5,3 +5,6 @@
 *.tmp
 *.orig
 .DS_Store
+# Local values overrides — never bundle secrets into a packaged chart
+my-secrets.yaml
+my-values.yaml

--- a/MosipNexus/helm/nexus-server/README.md
+++ b/MosipNexus/helm/nexus-server/README.md
@@ -2,8 +2,8 @@
 
 Helm chart for the MOSIP Nexus Server — RAG API, crawlers, ingestion, pgvector,
 and the scheduled jobs around it. A values-driven equivalent of the raw
-manifests in [`../../Server/k8s/`](../../Server/k8s/README.md); that directory
-is untouched and remains a valid alternative deployment path.
+manifests in [`../../Server/k8s/`](../../Server/k8s/README.md); both
+deployment paths remain valid alternatives.
 
 ## TL;DR
 
@@ -41,8 +41,10 @@ helm install nexus-server mosip/nexus-server \
 ## Installing
 
 ```console
-helm install nexus-server . --namespace mosip-nexus --create-namespace
+helm install nexus-server . --namespace mosip-nexus --create-namespace -f my-secrets.yaml
 ```
+
+(Chart fails to render without `secret.env.POSTGRES_PASSWORD`/`PG_CONNECTION` set — see [Secrets](#secrets).)
 
 One install serves **both** MOSIP and Inji — the client picks the product
 per-request (`X-Nexus-Product` header / `product` field), there's no
@@ -65,7 +67,8 @@ Delete them manually if you really want a clean slate.
 committing them:
 
 1. **Chart-managed** (`secret.create: true`, the default): override `secret.env`
-   via a local values file (`-f my-secrets.yaml`, gitignored) or `--set`.
+   via a local, gitignored values file (`-f my-secrets.yaml`). Avoid `--set` for
+   secret values — they'd end up in shell history, process listings, and CI logs.
 2. **Externally managed** (`secret.create: false`, `secret.existingSecret: nexus-env`):
    keep using [`../../Server/k8s/seal-secrets.sh`](../../Server/k8s/seal-secrets.sh) (sealed-secrets)
    or an ExternalSecret to produce the `nexus-env` Secret independently, and the

--- a/MosipNexus/helm/nexus-server/templates/_helpers.tpl
+++ b/MosipNexus/helm/nexus-server/templates/_helpers.tpl
@@ -52,8 +52,9 @@ app: {{ .name }}
 app.kubernetes.io/part-of: mosip-nexus
 app.kubernetes.io/managed-by: {{ .ctx.Release.Service }}
 helm.sh/chart: {{ .ctx.Chart.Name }}-{{ .ctx.Chart.Version }}
-{{- if .ctx.Values.commonLabels }}
-{{ toYaml .ctx.Values.commonLabels }}
+{{- $extra := omit (.ctx.Values.commonLabels | default dict) "app" }}
+{{- if $extra }}
+{{ toYaml $extra }}
 {{- end }}
 {{- end -}}
 

--- a/MosipNexus/helm/nexus-server/templates/backup-pvc.yaml
+++ b/MosipNexus/helm/nexus-server/templates/backup-pvc.yaml
@@ -8,7 +8,9 @@ metadata:
 spec:
   accessModes: {{- toYaml .Values.backup.pvc.accessModes | nindent 4 }}
   {{- $sc := include "nexus-server.storageClass" (dict "override" .Values.backup.pvc.storageClassName "ctx" $) }}
-  {{- if $sc }}
+  {{- if eq $sc "-" }}
+  storageClassName: ""
+  {{- else if $sc }}
   storageClassName: {{ $sc | quote }}
   {{- end }}
   resources:

--- a/MosipNexus/helm/nexus-server/templates/deployment.yaml
+++ b/MosipNexus/helm/nexus-server/templates/deployment.yaml
@@ -12,8 +12,9 @@ spec:
   template:
     metadata:
       labels: {{- include "nexus-server.labels" (dict "name" "nexus-api" "ctx" $) | nindent 8 }}
-        {{- if .Values.podLabels }}
-        {{- toYaml .Values.podLabels | nindent 8 }}
+        {{- $extraPodLabels := omit (.Values.podLabels | default dict) "app" }}
+        {{- if $extraPodLabels }}
+        {{- toYaml $extraPodLabels | nindent 8 }}
         {{- end }}
       {{- if .Values.podAnnotations }}
       annotations: {{- toYaml .Values.podAnnotations | nindent 8 }}

--- a/MosipNexus/helm/nexus-server/templates/initial-ingest-job.yaml
+++ b/MosipNexus/helm/nexus-server/templates/initial-ingest-job.yaml
@@ -2,6 +2,9 @@
 {{- if not .Values.updater.enabled }}
 {{ fail "initialIngest.enabled requires updater.enabled: true (initialIngest mounts the nexus-data PVC that the updater creates)." }}
 {{- end }}
+{{- if not .Values.postgres.enabled }}
+{{ fail "initialIngest.enabled requires postgres.enabled: true (initialIngest restores to nexus-postgres, which doesn't render when postgres.enabled is false)." }}
+{{- end }}
 # One-time bootstrap: restore vectors from an S3 snapshot instead of a 4-8 hour
 # re-embed. Runs as a post-install hook — fires once on `helm install` and
 # never again on `helm upgrade`. To re-run after a fresh snapshot:
@@ -121,9 +124,12 @@ spec:
               gunzip /vectors/nexus_vectors.dump.gz
 
               echo "Restoring into nexus-postgres (this takes ~5-10 minutes)..."
-              # --clean --if-exists makes this idempotent: safe whether postgres-data
-              # is a fresh empty PVC or already has a prior restore on it (e.g. after
-              # a delete+reinstall cycle — helm uninstall does not delete PVCs).
+              # --clean --if-exists makes this idempotent (won't error) whether
+              # postgres-data is empty or already has a prior restore on it. It is
+              # NOT consequence-free: --clean discards any data added since the
+              # snapshot, and running this while nexus-api serves traffic can cause
+              # request failures mid-restore. Stop traffic and take a fresh backup
+              # first if re-running deliberately, don't rely on this for routine ops.
               PGPASSWORD=$POSTGRES_PASSWORD pg_restore \
                 -h nexus-postgres \
                 -U mosip \

--- a/MosipNexus/helm/nexus-server/templates/postgres-pvc.yaml
+++ b/MosipNexus/helm/nexus-server/templates/postgres-pvc.yaml
@@ -9,7 +9,9 @@ spec:
   accessModes:
     - ReadWriteOnce
   {{- $sc := include "nexus-server.storageClass" (dict "override" .Values.postgres.storage.storageClassName "ctx" $) }}
-  {{- if $sc }}
+  {{- if eq $sc "-" }}
+  storageClassName: ""
+  {{- else if $sc }}
   storageClassName: {{ $sc | quote }}
   {{- end }}
   resources:

--- a/MosipNexus/helm/nexus-server/templates/secret.yaml
+++ b/MosipNexus/helm/nexus-server/templates/secret.yaml
@@ -1,4 +1,10 @@
 {{- if .Values.secret.create }}
+{{- if not .Values.secret.env.POSTGRES_PASSWORD }}
+{{ fail "secret.env.POSTGRES_PASSWORD must not be empty when secret.create: true — set a real password via a local values file (never commit it), or set secret.create: false and secret.existingSecret to a pre-created Secret instead." }}
+{{- end }}
+{{- if not .Values.secret.env.PG_CONNECTION }}
+{{ fail "secret.env.PG_CONNECTION must not be empty when secret.create: true — it must embed the same password as secret.env.POSTGRES_PASSWORD." }}
+{{- end }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/MosipNexus/helm/nexus-server/templates/updater-cronjob.yaml
+++ b/MosipNexus/helm/nexus-server/templates/updater-cronjob.yaml
@@ -23,7 +23,11 @@ spec:
             - name: updater
               image: {{ include "nexus-server.image" . }}
               imagePullPolicy: {{ include "nexus-server.imagePullPolicy" . }}
-              command:
+              # args (not command!) — see deployment.yaml for why: preserves the
+              # image's ENTRYPOINT (entrypoint.sh), which runs Alembic migrations
+              # first. Cheap when already at head, and keeps this CronJob
+              # consistent with the same "one entrypoint always migrates" contract.
+              args:
                 - uv
                 - run
                 - python

--- a/MosipNexus/helm/nexus-server/templates/updater-pvc.yaml
+++ b/MosipNexus/helm/nexus-server/templates/updater-pvc.yaml
@@ -12,7 +12,9 @@ metadata:
 spec:
   accessModes: {{- toYaml .Values.updater.pvc.accessModes | nindent 4 }}
   {{- $sc := include "nexus-server.storageClass" (dict "override" .Values.updater.pvc.storageClassName "ctx" $) }}
-  {{- if $sc }}
+  {{- if eq $sc "-" }}
+  storageClassName: ""
+  {{- else if $sc }}
   storageClassName: {{ $sc | quote }}
   {{- end }}
   resources:

--- a/MosipNexus/helm/nexus-server/values.yaml
+++ b/MosipNexus/helm/nexus-server/values.yaml
@@ -144,8 +144,11 @@ secret:
   ## stringData for the "nexus-env" Secret. Same keys as Server/.env.example.
   env:
     GROQ_API_KEY: ""
-    POSTGRES_PASSWORD: "changeme"
-    PG_CONNECTION: "postgresql+psycopg://mosip:changeme@nexus-postgres:5432/mosipnexus"
+    ## Required — chart fails to render (secret.create: true) if left empty.
+    ## Set a real value via a local, gitignored values file. PG_CONNECTION must
+    ## embed the same password.
+    POSTGRES_PASSWORD: ""
+    PG_CONNECTION: ""
     PRODUCT_NAME: "MOSIP Nexus"
     PRODUCT_SHORT: "MOSIP"
     PRODUCT_SLUG: "mosip"

--- a/MosipNexus/helm/nexus-ui/.helmignore
+++ b/MosipNexus/helm/nexus-ui/.helmignore
@@ -5,3 +5,6 @@
 *.tmp
 *.orig
 .DS_Store
+# Local values overrides — never bundle secrets into a packaged chart
+my-secrets.yaml
+my-values.yaml

--- a/MosipNexus/helm/nexus-ui/templates/NOTES.txt
+++ b/MosipNexus/helm/nexus-ui/templates/NOTES.txt
@@ -7,7 +7,7 @@ Routing: Istio VirtualService, attached to gateway "{{ .Values.routing.istio.gat
 {{- else }}
 
 Routing: nginx Ingress
-  https://{{ .Values.routing.ingress.host }}
+  {{- if .Values.routing.ingress.tls.enabled }}https{{- else }}http{{- end }}://{{ .Values.routing.ingress.host }}
 {{- end }}
 
 The UI's nginx proxies same-origin /api/* to the "nexus-api" Service — make

--- a/MosipNexus/helm/nexus-ui/templates/_helpers.tpl
+++ b/MosipNexus/helm/nexus-ui/templates/_helpers.tpl
@@ -34,8 +34,9 @@ app: nexus-ui
 app.kubernetes.io/part-of: mosip-nexus
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-{{- if .Values.commonLabels }}
-{{ toYaml .Values.commonLabels }}
+{{- $extra := omit (.Values.commonLabels | default dict) "app" }}
+{{- if $extra }}
+{{ toYaml $extra }}
 {{- end }}
 {{- end -}}
 

--- a/MosipNexus/helm/nexus-ui/templates/deployment.yaml
+++ b/MosipNexus/helm/nexus-ui/templates/deployment.yaml
@@ -12,8 +12,9 @@ spec:
   template:
     metadata:
       labels: {{- include "nexus-ui.labels" . | nindent 8 }}
-        {{- if .Values.podLabels }}
-        {{- toYaml .Values.podLabels | nindent 8 }}
+        {{- $extraPodLabels := omit (.Values.podLabels | default dict) "app" }}
+        {{- if $extraPodLabels }}
+        {{- toYaml $extraPodLabels | nindent 8 }}
         {{- end }}
       {{- if .Values.podAnnotations }}
       annotations: {{- toYaml .Values.podAnnotations | nindent 8 }}


### PR DESCRIPTION
Fixup for #75 — targets its branch (\`mosip-nexus-helm-deploy-agents\`), not \`develop\`. Merge this into that branch and #75 will pick it up.

## Summary

Full triage of all 19 findings (18 CodeRabbit + 1 CodeQL) discussed in the PR conversation. Fixed 18, skipped 1 with reason:

- **Workflow**: \`type: string\`→\`type: choice\` (actionlint error), pinned \`mosip/kattu\` ref + 4 lint-config URLs to a verified commit SHA, added \`permissions: {contents: read}\`
- **`.helmignore`** (both charts): exclude local secret override files from packaged \`.tgz\`
- **`deploy/*/install.sh`**: scope rollout status to the release's own Deployment, not every Deployment in the namespace
- **`deploy/*/delete.sh`**: fixed Y/n prompt logic (said Y/n, only accepted literal \`Y\`)
- **`initial-ingest-job.yaml`**: added \`postgres.enabled\` fail-fast guard (Job waits on a Service that doesn't render when postgres is disabled)
- **3 PVC templates**: the \`"-"\` storageClass sentinel now correctly renders as an empty string, not a literal \`"-"\`
- **`updater-cronjob.yaml`** (chart) + **`06-cronjob.yaml`** (raw manifest): same \`command:\`→\`args:\` migration-skipping bug the API Deployment already had fixed
- **`values.yaml`**: removed the hardcoded \`POSTGRES_PASSWORD: "changeme"\` default; \`secret.yaml\` now fails fast with a clear message instead of ever deploying a known-weak credential — kept \`secret.create: true\` as default (unlike CodeRabbit's exact diff) to preserve the documented one-line quick-start
- **Both charts' label helpers + `deployment.yaml`**: \`commonLabels\`/\`podLabels\` can no longer override the fixed \`app\` selector label — also fixed an edge case my own fix introduced (an all-\`app\` label map left an empty map that broke YAML rendering), caught during verification before this even reached review
- **`NOTES.txt`**: TLS-aware URL in nginx mode
- **`AGENTS.md`** files (root, Server, UI): documented runtime prerequisites, qualified the "no CI" claims now that chart-lint-publish/docker-build workflows exist, fixed markdownlint MD031/MD040
- **`initial-ingest-job.yaml`** (both, both comment sites): reworded "safe to re-run" — idempotent (won't error) is not the same as consequence-free (\`--clean\` discards data added since the snapshot)

**Skipped**: removing \`PRODUCT_NAME\`/\`PRODUCT_SHORT\`/\`PRODUCT_SLUG\` from values — these are crawl-tool process-level defaults, not per-request product routing, already established earlier in this session. CodeRabbit's own comment flags this as a "heavy lift" needing a Server-side change too.

## Test plan
- [x] \`helm lint\` clean on both charts
- [x] \`helm template\` across the toggle matrix: default (with password supplied), \`postgres.enabled=false\`+\`initialIngest.enabled=true\` (fails fast), \`storageClassName=-\` (renders \`""\`), \`commonLabels.app\`/\`podLabels.app\` override (doesn't hijack selector, doesn't break YAML)
- [x] \`python3 -c "import yaml"\` parse check on both edited raw manifests
- [x] \`bash -n\` on all 4 edited deploy scripts
- [ ] DCO passes
- [ ] CodeRabbit re-review clears

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A5KE4fZxHqbeiDaUJenSfU