### PR TITLE
Add MosipNexus chart-lint-publish workflow to master

### DIFF
--- a/.github/workflows/mosip-nexus-chart-lint-publish.yml
+++ b/.github/workflows/mosip-nexus-chart-lint-publish.yml
@@ -1,0 +1,77 @@
+# Present on master (in addition to develop) so GitHub properly registers this
+# workflow's `workflow_dispatch`/`release` triggers — those only resolve against
+# whatever version of a workflow file exists on the repo's DEFAULT branch,
+# unlike `push`/`pull_request` which are ref-scoped. MosipNexus itself hasn't
+# been promoted to master yet, so the push/pull_request path filters below stay
+# dormant here; dispatch this workflow with `ref: develop` (or wherever the
+# chart content actually lives) to run it for real.
+name: MosipNexus — Validate / Publish helm charts
+
+on:
+  release:
+    types: [published]
+  pull_request:
+    types: [opened, reopened, synchronize]
+    paths:
+      - 'MosipNexus/helm/**'
+  workflow_dispatch:
+    inputs:
+      IGNORE_CHARTS:
+        description: 'Provide list of charts to be ignored separated by pipe(|)'
+        required: false
+        default: ''
+        type: string
+      CHART_PUBLISH:
+        description: 'Chart publishing to gh-pages branch'
+        required: false
+        default: 'NO'
+        type: choice
+        options:
+          - YES
+          - NO
+      INCLUDE_ALL_CHARTS:
+        description: 'Include all charts for Linting/Publishing (YES/NO)'
+        required: false
+        default: 'NO'
+        type: choice
+        options:
+          - YES
+          - NO
+  push:
+    branches:
+      - '!release-branch'
+      - master
+      - develop
+    paths:
+      - 'MosipNexus/helm/**'
+
+jobs:
+  # MosipNexus/helm/ contains both nexus-server and nexus-ui as chart
+  # subfolders (mirrors github-activity-tracker/helm/{gh-tracker-ui,gh-tracker-service})
+  # so one CHARTS_DIR covers both.
+  chart-lint-publish:
+    permissions:
+      contents: read
+    uses: mosip/kattu/.github/workflows/chart-lint-publish.yml@4e9370bc8edcdada050ccac663a9c751af7ec0aa
+    with:
+      CHARTS_DIR: ./MosipNexus/helm
+      CHARTS_URL: https://mosip.github.io/mosip-helm
+      REPOSITORY: mosip-helm
+      BRANCH: gh-pages
+      # Always YES: kattu's changed-chart detection greps changed file paths for a
+      # "/charts/" path segment to build an ignore-list, but this dir is "helm/",
+      # not "charts/" — that regex never matches, so CHARTS_MODIFIED comes back
+      # empty and BOTH charts land in the ignore list ("CHARTS list is empty;
+      # SKIPPING OPERATION" — silently skips lint AND publish, every run). We
+      # only have two small charts here, so always processing both is fine.
+      INCLUDE_ALL_CHARTS: "${{ inputs.INCLUDE_ALL_CHARTS || 'YES' }}"
+      IGNORE_CHARTS: "${{ inputs.IGNORE_CHARTS || '' }}"
+      # pull_request runs are always lint-only — never publish credentials to a PR build.
+      CHART_PUBLISH: "${{ github.event_name == 'pull_request' && 'NO' || (inputs.CHART_PUBLISH || 'YES') }}"
+      LINTING_CHART_SCHEMA_YAML_URL: "https://raw.githubusercontent.com/mosip/kattu/4e9370bc8edcdada050ccac663a9c751af7ec0aa/.github/helm-lint-configs/chart-schema.yaml"
+      LINTING_LINTCONF_YAML_URL: "https://raw.githubusercontent.com/mosip/kattu/4e9370bc8edcdada050ccac663a9c751af7ec0aa/.github/helm-lint-configs/lintconf.yaml"
+      LINTING_CHART_TESTING_CONFIG_YAML_URL: "https://raw.githubusercontent.com/mosip/kattu/4e9370bc8edcdada050ccac663a9c751af7ec0aa/.github/helm-lint-configs/chart-testing-config.yaml"
+      LINTING_HEALTH_CHECK_SCHEMA_YAML_URL: "https://raw.githubusercontent.com/mosip/kattu/4e9370bc8edcdada050ccac663a9c751af7ec0aa/.github/helm-lint-configs/health-check-schema.yaml"
+    secrets:
+      TOKEN: ${{ secrets.ACTION_PAT }}
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/mosip-nexus-chart-lint-publish.yml` to `master`, matching `develop`'s current content verbatim.
- **Why**: GitHub only resolves `workflow_dispatch`/`release` triggers against whatever version of a workflow file exists on the repo's **default branch**. Since this workflow only existed on `develop`, every `workflow_dispatch` attempt (CLI, API, or presumably the Actions UI) fails with a 422 `"not in the list of allowed values"` — even for the input's own declared default. `push`/`pull_request` triggers are ref-scoped and unaffected by this.
- `MosipNexus/` hasn't been promoted to `master` yet, so this file's own `push`/`pull_request` path filters (`MosipNexus/helm/**`) stay dormant on `master` — its purpose here is solely to register the `workflow_dispatch` input schema with GitHub. Actual runs should be dispatched with `ref: develop` (or wherever the chart content lives) to execute for real.
- No other files touched — confirmed only the workflow file is in this PR, nothing from `MosipNexus/` itself.

## Test plan
- [x] YAML parses cleanly
- [ ] After merge: `gh workflow run mosip-nexus-chart-lint-publish.yml --ref develop -f CHART_PUBLISH=YES -f INCLUDE_ALL_CHARTS=YES` should succeed instead of 422ing
- [ ] Confirm nexus-server/nexus-ui actually appear in `helm search repo mosip` afterward

🤖 Generated with [Claude Code](https://claude.com/claude-code)