### PR TITLE
Fix workflow_dispatch inputs on MosipNexus chart publish workflow

### DIFF
--- a/.github/workflows/mosip-nexus-chart-lint-publish.yml
+++ b/.github/workflows/mosip-nexus-chart-lint-publish.yml
@@ -24,19 +24,13 @@ on:
       CHART_PUBLISH:
         description: 'Chart publishing to gh-pages branch'
         required: false
-        default: 'NO'
-        type: choice
-        options:
-          - YES
-          - NO
+        default: true
+        type: boolean
       INCLUDE_ALL_CHARTS:
-        description: 'Include all charts for Linting/Publishing (YES/NO)'
+        description: 'Include all charts for Linting/Publishing'
         required: false
-        default: 'NO'
-        type: choice
-        options:
-          - YES
-          - NO
+        default: true
+        type: boolean
   push:
     branches:
       - '!release-branch'
@@ -58,16 +52,18 @@ jobs:
       CHARTS_URL: https://mosip.github.io/mosip-helm
       REPOSITORY: mosip-helm
       BRANCH: gh-pages
-      # Always YES: kattu's changed-chart detection greps changed file paths for a
-      # "/charts/" path segment to build an ignore-list, but this dir is "helm/",
-      # not "charts/" — that regex never matches, so CHARTS_MODIFIED comes back
-      # empty and BOTH charts land in the ignore list ("CHARTS list is empty;
-      # SKIPPING OPERATION" — silently skips lint AND publish, every run). We
-      # only have two small charts here, so always processing both is fine.
-      INCLUDE_ALL_CHARTS: "${{ inputs.INCLUDE_ALL_CHARTS || 'YES' }}"
+      # Always YES on push/release: kattu's changed-chart detection greps changed file
+      # paths for a "/charts/" path segment to build an ignore-list, but this dir is
+      # "helm/", not "charts/" — that regex never matches, so CHARTS_MODIFIED comes
+      # back empty and BOTH charts land in the ignore list ("CHARTS list is empty;
+      # SKIPPING OPERATION" — silently skips lint AND publish, every run). We only
+      # have two small charts here, so always processing both is fine. kattu itself
+      # takes this as a plain string compared only against the literal "NO", so the
+      # boolean input here is translated to "YES"/"NO" below.
+      INCLUDE_ALL_CHARTS: "${{ (github.event_name != 'workflow_dispatch' || inputs.INCLUDE_ALL_CHARTS) && 'YES' || 'NO' }}"
       IGNORE_CHARTS: "${{ inputs.IGNORE_CHARTS || '' }}"
       # pull_request runs are always lint-only — never publish credentials to a PR build.
-      CHART_PUBLISH: "${{ github.event_name == 'pull_request' && 'NO' || (inputs.CHART_PUBLISH || 'YES') }}"
+      CHART_PUBLISH: "${{ github.event_name == 'pull_request' && 'NO' || ((github.event_name != 'workflow_dispatch' || inputs.CHART_PUBLISH) && 'YES' || 'NO') }}"
       LINTING_CHART_SCHEMA_YAML_URL: "https://raw.githubusercontent.com/mosip/kattu/4e9370bc8edcdada050ccac663a9c751af7ec0aa/.github/helm-lint-configs/chart-schema.yaml"
       LINTING_LINTCONF_YAML_URL: "https://raw.githubusercontent.com/mosip/kattu/4e9370bc8edcdada050ccac663a9c751af7ec0aa/.github/helm-lint-configs/lintconf.yaml"
       LINTING_CHART_TESTING_CONFIG_YAML_URL: "https://raw.githubusercontent.com/mosip/kattu/4e9370bc8edcdada050ccac663a9c751af7ec0aa/.github/helm-lint-configs/chart-testing-config.yaml"


### PR DESCRIPTION
Replaces #80 (same change, re-pushed with a DCO sign-off — the original commit on that branch was missing `Signed-off-by`, and that branch has repo rules blocking both force-push and delete, so a fresh branch was needed).

## Summary
- `CHART_PUBLISH`/`INCLUDE_ALL_CHARTS` were `type: choice` with `YES`/`NO` options; dispatching via `gh workflow run`/API with the exact literal value still 422'd repeatedly ("not in the list of allowed values"), even after the workflow file existed on `master`.
- Switched both to `type: boolean` (checkbox in the UI, validated as true/false — avoids the choice-input validation path entirely) and translate to the `"YES"`/`"NO"` strings the `mosip/kattu` reusable workflow expects internally via the `with:` expressions.
- Behavior preserved: `push`/`release` runs still always resolve `INCLUDE_ALL_CHARTS=YES` (works around kattu's `/charts/` vs `helm/` path-matching bug) and `CHART_PUBLISH=YES` (except `pull_request`, always lint-only).

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` — YAML parses cleanly
- [ ] Dispatch via Actions web UI (checkboxes checked) against `ref: develop`, confirm the run's logs show `INCLUDE_ALL_CHARTS`/`CHART_PUBLISH` resolving to literal `YES`
- [ ] Confirm real publish via `helm search repo mosip/nexus-server mosip/nexus-ui` / `mosip-helm` gh-pages `index.yaml`

https://claude.ai/code/session_01A5KE4fZxHqbeiDaUJenSfU