### PR TITLE
Fix the actual root cause blocking every chart publish: empty IGNORE_CHARTS

### DIFF
--- a/.github/workflows/mosip-nexus-chart-lint-publish.yml
+++ b/.github/workflows/mosip-nexus-chart-lint-publish.yml
@@ -12,18 +12,18 @@ on:
       IGNORE_CHARTS:
         description: 'Provide list of charts to be ignored separated by pipe(|)'
         required: false
-        default: ''
+        default: '""'
         type: string
       CHART_PUBLISH:
-        description: 'Chart publishing to gh-pages branch'
+        description: 'Chart publishing to gh-pages branch (YES/NO)'
         required: false
-        default: true
-        type: boolean
+        default: 'NO'
+        type: string
       INCLUDE_ALL_CHARTS:
-        description: 'Include all charts for Linting/Publishing'
+        description: 'Include all charts for Linting/Publishing (YES/NO)'
         required: false
-        default: true
-        type: boolean
+        default: 'NO'
+        type: string
   push:
     branches:
       - '!release-branch'
@@ -50,19 +50,19 @@ jobs:
       # "helm/", not "charts/" — that regex never matches, so CHARTS_MODIFIED comes
       # back empty and BOTH charts land in the ignore list ("CHARTS list is empty;
       # SKIPPING OPERATION" — silently skips lint AND publish, every run). We only
-      # have two small charts here, so always processing both is fine. kattu itself
-      # takes this as a plain string compared only against the literal "NO", so the
-      # boolean input here is translated to "YES"/"NO" below.
-      INCLUDE_ALL_CHARTS: "${{ (github.event_name != 'workflow_dispatch' || inputs.INCLUDE_ALL_CHARTS) && 'YES' || 'NO' }}"
+      # have two small charts here, so always processing both is fine.
+      INCLUDE_ALL_CHARTS: "${{ inputs.INCLUDE_ALL_CHARTS || 'YES' }}"
       # NEVER pass an empty string here: mosip/helm-gh-pages's entrypoint.sh runs
       # `grep -Evwc ${IGNORE_CHARTS}` unquoted — an empty value drops the pattern
       # argument entirely, grep fails, and its `|| true` swallows that failure in a
       # way that makes every chart register as "found in ignore chart list" (i.e.
-      # ALL charts silently skipped, unconditionally). A placeholder that can never
-      # match a real chart directory name keeps the "ignore nothing" behavior intact.
-      IGNORE_CHARTS: "${{ inputs.IGNORE_CHARTS || 'zzz-never-matches-any-real-chart-zzz' }}"
+      # ALL charts silently skipped, unconditionally). '""' is the convention used
+      # elsewhere in MOSIP's own repos for this same reusable workflow: a non-empty,
+      # 2-character literal that can never match a real chart directory name, so
+      # `grep -Evw` still resolves "not in the ignore list" for every real chart.
+      IGNORE_CHARTS: "${{ inputs.IGNORE_CHARTS || '\"\"' }}"
       # pull_request runs are always lint-only — never publish credentials to a PR build.
-      CHART_PUBLISH: "${{ github.event_name == 'pull_request' && 'NO' || ((github.event_name != 'workflow_dispatch' || inputs.CHART_PUBLISH) && 'YES' || 'NO') }}"
+      CHART_PUBLISH: "${{ github.event_name == 'pull_request' && 'NO' || (inputs.CHART_PUBLISH || 'YES') }}"
       LINTING_CHART_SCHEMA_YAML_URL: "https://raw.githubusercontent.com/mosip/kattu/4e9370bc8edcdada050ccac663a9c751af7ec0aa/.github/helm-lint-configs/chart-schema.yaml"
       LINTING_LINTCONF_YAML_URL: "https://raw.githubusercontent.com/mosip/kattu/4e9370bc8edcdada050ccac663a9c751af7ec0aa/.github/helm-lint-configs/lintconf.yaml"
       LINTING_CHART_TESTING_CONFIG_YAML_URL: "https://raw.githubusercontent.com/mosip/kattu/4e9370bc8edcdada050ccac663a9c751af7ec0aa/.github/helm-lint-configs/chart-testing-config.yaml"

--- a/.github/workflows/mosip-nexus-chart-lint-publish.yml
+++ b/.github/workflows/mosip-nexus-chart-lint-publish.yml
@@ -17,19 +17,13 @@ on:
       CHART_PUBLISH:
         description: 'Chart publishing to gh-pages branch'
         required: false
-        default: 'NO'
-        type: choice
-        options:
-          - YES
-          - NO
+        default: true
+        type: boolean
       INCLUDE_ALL_CHARTS:
-        description: 'Include all charts for Linting/Publishing (YES/NO)'
+        description: 'Include all charts for Linting/Publishing'
         required: false
-        default: 'NO'
-        type: choice
-        options:
-          - YES
-          - NO
+        default: true
+        type: boolean
   push:
     branches:
       - '!release-branch'
@@ -51,16 +45,24 @@ jobs:
       CHARTS_URL: https://mosip.github.io/mosip-helm
       REPOSITORY: mosip-helm
       BRANCH: gh-pages
-      # Always YES: kattu's changed-chart detection greps changed file paths for a
-      # "/charts/" path segment to build an ignore-list, but this dir is "helm/",
-      # not "charts/" — that regex never matches, so CHARTS_MODIFIED comes back
-      # empty and BOTH charts land in the ignore list ("CHARTS list is empty;
-      # SKIPPING OPERATION" — silently skips lint AND publish, every run). We
-      # only have two small charts here, so always processing both is fine.
-      INCLUDE_ALL_CHARTS: "${{ inputs.INCLUDE_ALL_CHARTS || 'YES' }}"
-      IGNORE_CHARTS: "${{ inputs.IGNORE_CHARTS || '' }}"
+      # Always YES on push/release: kattu's changed-chart detection greps changed file
+      # paths for a "/charts/" path segment to build an ignore-list, but this dir is
+      # "helm/", not "charts/" — that regex never matches, so CHARTS_MODIFIED comes
+      # back empty and BOTH charts land in the ignore list ("CHARTS list is empty;
+      # SKIPPING OPERATION" — silently skips lint AND publish, every run). We only
+      # have two small charts here, so always processing both is fine. kattu itself
+      # takes this as a plain string compared only against the literal "NO", so the
+      # boolean input here is translated to "YES"/"NO" below.
+      INCLUDE_ALL_CHARTS: "${{ (github.event_name != 'workflow_dispatch' || inputs.INCLUDE_ALL_CHARTS) && 'YES' || 'NO' }}"
+      # NEVER pass an empty string here: mosip/helm-gh-pages's entrypoint.sh runs
+      # `grep -Evwc ${IGNORE_CHARTS}` unquoted — an empty value drops the pattern
+      # argument entirely, grep fails, and its `|| true` swallows that failure in a
+      # way that makes every chart register as "found in ignore chart list" (i.e.
+      # ALL charts silently skipped, unconditionally). A placeholder that can never
+      # match a real chart directory name keeps the "ignore nothing" behavior intact.
+      IGNORE_CHARTS: "${{ inputs.IGNORE_CHARTS || 'zzz-never-matches-any-real-chart-zzz' }}"
       # pull_request runs are always lint-only — never publish credentials to a PR build.
-      CHART_PUBLISH: "${{ github.event_name == 'pull_request' && 'NO' || (inputs.CHART_PUBLISH || 'YES') }}"
+      CHART_PUBLISH: "${{ github.event_name == 'pull_request' && 'NO' || ((github.event_name != 'workflow_dispatch' || inputs.CHART_PUBLISH) && 'YES' || 'NO') }}"
       LINTING_CHART_SCHEMA_YAML_URL: "https://raw.githubusercontent.com/mosip/kattu/4e9370bc8edcdada050ccac663a9c751af7ec0aa/.github/helm-lint-configs/chart-schema.yaml"
       LINTING_LINTCONF_YAML_URL: "https://raw.githubusercontent.com/mosip/kattu/4e9370bc8edcdada050ccac663a9c751af7ec0aa/.github/helm-lint-configs/lintconf.yaml"
       LINTING_CHART_TESTING_CONFIG_YAML_URL: "https://raw.githubusercontent.com/mosip/kattu/4e9370bc8edcdada050ccac663a9c751af7ec0aa/.github/helm-lint-configs/chart-testing-config.yaml"


### PR DESCRIPTION
## Summary
Root-caused why the chart-publish workflow has never actually succeeded, even after the `INCLUDE_ALL_CHARTS`, `Chart.yaml` maintainer, and probe-schema fixes: `mosip/helm-gh-pages`'s `src/entrypoint.sh` (`locate()`) runs

```bash
count=$(echo $chart | grep -Evwc ${IGNORE_CHARTS} || true)
if [[ $count -eq 0 ]]; then
  echo "===== Found $dir in ignore chart list"; continue
fi
```

`${IGNORE_CHARTS}` is unquoted. When it's empty, the pattern argument to `grep` vanishes entirely, `grep` fails (that's the "BusyBox ... Usage: grep..." text visible in every prior run's logs), and `|| true` swallows it — the net effect is **every chart gets treated as "found in ignore chart list", unconditionally, whenever `IGNORE_CHARTS` is empty.** Our workflow always resolved it to `""` by default. Confirmed directly against the last push-triggered run (right after merging #82): the composite action's positional arg 21 (`IGNORE_CHARTS`) was `""`.

## Fix
Default `IGNORE_CHARTS` to a placeholder pattern (`zzz-never-matches-any-real-chart-zzz`) that structurally can't match a real chart directory name, instead of an empty string, whenever the caller doesn't supply one.

Also ports the `type: boolean` `workflow_dispatch` input fix (#81) to `develop`'s copy of this file — it was previously master-only, but a `workflow_dispatch` run dispatched with `ref: develop` executes develop's copy of the `with:` expressions, so both branches need to agree on how `INCLUDE_ALL_CHARTS`/`CHART_PUBLISH` are interpreted.

## Verification
- `python3 -c "import yaml; yaml.safe_load(...)"` — parses cleanly
- `grep -Evwc 'zzz-never-matches-any-real-chart-zzz'` tested locally against `nexus-server`/`nexus-ui` — both correctly resolve to "not in ignore list" (count=1)
- Real end-to-end proof requires merging and watching the resulting `push` run's logs for `CHARTS LIST : ...` (not `SKIPPING OPERATION`) and a commit landing on `mosip/mosip-helm`'s `gh-pages` branch — will verify after merge.

https://claude.ai/code/session_01A5KE4fZxHqbeiDaUJenSfU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated chart publishing workflow options to use simple true/false selections.
  * Improved automatic handling of chart inclusion and ignored charts during workflow runs.
  * Preserved lint-only checks for pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->