### PR TITLE
Sync master's chart-publish workflow with the develop-side fixes

### DIFF
--- a/.github/workflows/mosip-nexus-chart-lint-publish.yml
+++ b/.github/workflows/mosip-nexus-chart-lint-publish.yml
@@ -19,18 +19,18 @@ on:
       IGNORE_CHARTS:
         description: 'Provide list of charts to be ignored separated by pipe(|)'
         required: false
-        default: ''
+        default: '""'
         type: string
       CHART_PUBLISH:
-        description: 'Chart publishing to gh-pages branch'
+        description: 'Chart publishing to gh-pages branch (YES/NO)'
         required: false
-        default: true
-        type: boolean
+        default: 'NO'
+        type: string
       INCLUDE_ALL_CHARTS:
-        description: 'Include all charts for Linting/Publishing'
+        description: 'Include all charts for Linting/Publishing (YES/NO)'
         required: false
-        default: true
-        type: boolean
+        default: 'NO'
+        type: string
   push:
     branches:
       - '!release-branch'
@@ -57,13 +57,19 @@ jobs:
       # "helm/", not "charts/" — that regex never matches, so CHARTS_MODIFIED comes
       # back empty and BOTH charts land in the ignore list ("CHARTS list is empty;
       # SKIPPING OPERATION" — silently skips lint AND publish, every run). We only
-      # have two small charts here, so always processing both is fine. kattu itself
-      # takes this as a plain string compared only against the literal "NO", so the
-      # boolean input here is translated to "YES"/"NO" below.
-      INCLUDE_ALL_CHARTS: "${{ (github.event_name != 'workflow_dispatch' || inputs.INCLUDE_ALL_CHARTS) && 'YES' || 'NO' }}"
-      IGNORE_CHARTS: "${{ inputs.IGNORE_CHARTS || '' }}"
+      # have two small charts here, so always processing both is fine.
+      INCLUDE_ALL_CHARTS: "${{ inputs.INCLUDE_ALL_CHARTS || 'YES' }}"
+      # NEVER pass an empty string here: mosip/helm-gh-pages's entrypoint.sh runs
+      # `grep -Evwc ${IGNORE_CHARTS}` unquoted — an empty value drops the pattern
+      # argument entirely, grep fails, and its `|| true` swallows that failure in a
+      # way that makes every chart register as "found in ignore chart list" (i.e.
+      # ALL charts silently skipped, unconditionally). '""' is the convention used
+      # elsewhere in MOSIP's own repos for this same reusable workflow: a non-empty,
+      # 2-character literal that can never match a real chart directory name, so
+      # `grep -Evw` still resolves "not in the ignore list" for every real chart.
+      IGNORE_CHARTS: "${{ inputs.IGNORE_CHARTS || '\"\"' }}"
       # pull_request runs are always lint-only — never publish credentials to a PR build.
-      CHART_PUBLISH: "${{ github.event_name == 'pull_request' && 'NO' || ((github.event_name != 'workflow_dispatch' || inputs.CHART_PUBLISH) && 'YES' || 'NO') }}"
+      CHART_PUBLISH: "${{ github.event_name == 'pull_request' && 'NO' || (inputs.CHART_PUBLISH || 'YES') }}"
       LINTING_CHART_SCHEMA_YAML_URL: "https://raw.githubusercontent.com/mosip/kattu/4e9370bc8edcdada050ccac663a9c751af7ec0aa/.github/helm-lint-configs/chart-schema.yaml"
       LINTING_LINTCONF_YAML_URL: "https://raw.githubusercontent.com/mosip/kattu/4e9370bc8edcdada050ccac663a9c751af7ec0aa/.github/helm-lint-configs/lintconf.yaml"
       LINTING_CHART_TESTING_CONFIG_YAML_URL: "https://raw.githubusercontent.com/mosip/kattu/4e9370bc8edcdada050ccac663a9c751af7ec0aa/.github/helm-lint-configs/chart-testing-config.yaml"


### PR DESCRIPTION
## Summary
`workflow_dispatch`'s input schema is always drawn from the file on the default branch (`master`), even when dispatching against a different `ref`. #83 (still open, targets `develop`) fixes the two real bugs blocking every chart publish, but only on `develop`'s copy of this workflow file — this PR ports the same fixes to `master`'s copy so the two stay consistent (otherwise a UI dispatch against `develop` would send `true`/`false` into an execution context that now expects `"YES"`/`"NO"` strings).

- `IGNORE_CHARTS` default: `''` → `'""'` (2-character literal). `mosip/helm-gh-pages`'s `entrypoint.sh` runs `grep -Evwc ${IGNORE_CHARTS}` unquoted — an empty value drops the pattern argument entirely, and via `|| true` every chart ends up registered as "in the ignore list," silently skipping the whole run. This is the actual root cause behind every "CHARTS list is empty; SKIPPING OPERATION" seen throughout this effort (see #83 for the full writeup).
- `CHART_PUBLISH`/`INCLUDE_ALL_CHARTS`: `type: boolean` (from #81) → `type: string`, matching the convention already used for this same reusable workflow in other MOSIP repos. `type: choice` kept 422'ing on dispatch even with the exact literal option value; `type: string` isn't subject to that validation path.

## Verification
- `python3 -c "import yaml; yaml.safe_load(...)"` — parses cleanly
- Diff is scoped to only this workflow file

https://claude.ai/code/session_01A5KE4fZxHqbeiDaUJenSfU