### PR TITLE
Use .Release.Namespace instead of a separate values.yaml namespace field

### DIFF
--- a/MosipNexus/helm/nexus-server/Chart.yaml
+++ b/MosipNexus/helm/nexus-server/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nexus-server
 description: Helm chart for the MOSIP Nexus Server (RAG API, crawlers, ingestion, MCP)
 type: application
-version: 1.0.0
+version: 1.0.1
 appVersion: "1.0.0"
 home: https://docs.mosip.io
 keywords:

--- a/MosipNexus/helm/nexus-server/Chart.yaml
+++ b/MosipNexus/helm/nexus-server/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nexus-server
 description: Helm chart for the MOSIP Nexus Server (RAG API, crawlers, ingestion, MCP)
 type: application
-version: 1.0.1
+version: 1.0.0
 appVersion: "1.0.0"
 home: https://docs.mosip.io
 keywords:

--- a/MosipNexus/helm/nexus-server/README.md
+++ b/MosipNexus/helm/nexus-server/README.md
@@ -97,9 +97,10 @@ mutually exclusive templates:
 
 ## Key parameters
 
+Namespace isn't a chart parameter — every resource uses `.Release.Namespace`, so it's whatever namespace you pass to `helm install`/`upgrade -n <ns>` (see [Installing](#installing)).
+
 | Parameter | Default | Description |
 | --- | --- | --- |
-| `namespace` | `mosip-nexus` | Namespace for all resources (create with `--create-namespace`) |
 | `storageClassName` | `""` (cluster default) | Default StorageClass for all three PVCs (postgres/updater/backup). Each PVC's own `*.storageClassName` overrides this individually |
 | `image.repository` / `image.tag` | `nexus-server` / `v1.0.0` | API + jobs image |
 | `api.workers` / `api.limitConcurrency` | `1` / `64` | uvicorn flags |

--- a/MosipNexus/helm/nexus-server/templates/NOTES.txt
+++ b/MosipNexus/helm/nexus-server/templates/NOTES.txt
@@ -1,4 +1,4 @@
-MOSIP Nexus Server ({{ .Chart.Name }} {{ .Chart.Version }}) has been installed into namespace "{{ .Values.namespace }}".
+MOSIP Nexus Server ({{ .Chart.Name }} {{ .Chart.Version }}) has been installed into namespace "{{ .Release.Namespace }}".
 
 {{- if eq .Values.api.routing.mode "istio" }}
 
@@ -13,18 +13,18 @@ Routing: nginx Ingress
 {{- if .Values.updater.enabled }}
 
 Trigger the first knowledge-base crawl now (don't wait for the nightly schedule):
-  kubectl create job --from=cronjob/nexus-updater nexus-updater-init -n {{ .Values.namespace }}
+  kubectl create job --from=cronjob/nexus-updater nexus-updater-init -n {{ .Release.Namespace }}
 {{- end }}
 
 {{- if .Values.initialIngest.enabled }}
 
 A one-time S3 vector-snapshot restore Job ("nexus-initial-ingest") ran as a
 post-install hook. Check its status:
-  kubectl get job nexus-initial-ingest -n {{ .Values.namespace }}
+  kubectl get job nexus-initial-ingest -n {{ .Release.Namespace }}
 {{- end }}
 
 Check health:
-  kubectl port-forward -n {{ .Values.namespace }} svc/nexus-api 8010:8000
+  kubectl port-forward -n {{ .Release.Namespace }} svc/nexus-api 8010:8000
   curl http://localhost:8010/health
 
 Next: install the helm/nexus-ui chart.

--- a/MosipNexus/helm/nexus-server/templates/backup-cronjob.yaml
+++ b/MosipNexus/helm/nexus-server/templates/backup-cronjob.yaml
@@ -1,14 +1,14 @@
 {{- if .Values.backup.enabled }}
 # Restore from backup:
-#   POD=$(kubectl get pod -n {{ .Values.namespace }} -l app=nexus-postgres -o name | head -1)
-#   kubectl exec -n {{ .Values.namespace }} $POD -- pg_restore -U mosip -d mosipnexus /backups/nexus_<DATE>.dump
+#   POD=$(kubectl get pod -n {{ .Release.Namespace }} -l app=nexus-postgres -o name | head -1)
+#   kubectl exec -n {{ .Release.Namespace }} $POD -- pg_restore -U mosip -d mosipnexus /backups/nexus_<DATE>.dump
 # Trigger a manual backup:
-#   kubectl create job --from=cronjob/nexus-db-backup nexus-db-backup-manual -n {{ .Values.namespace }}
+#   kubectl create job --from=cronjob/nexus-db-backup nexus-db-backup-manual -n {{ .Release.Namespace }}
 apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: nexus-db-backup
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "nexus-server.labels" (dict "name" "nexus-db-backup" "ctx" $) | nindent 4 }}
 spec:
   schedule: {{ .Values.backup.schedule | quote }}

--- a/MosipNexus/helm/nexus-server/templates/backup-pvc.yaml
+++ b/MosipNexus/helm/nexus-server/templates/backup-pvc.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: nexus-db-backups
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "nexus-server.labels" (dict "name" "nexus-db-backup" "ctx" $) | nindent 4 }}
 spec:
   accessModes: {{- toYaml .Values.backup.pvc.accessModes | nindent 4 }}

--- a/MosipNexus/helm/nexus-server/templates/deployment.yaml
+++ b/MosipNexus/helm/nexus-server/templates/deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: nexus-api
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "nexus-server.labels" (dict "name" "nexus-api" "ctx" $) | nindent 4 }}
   annotations: {{- include "nexus-server.annotations" (dict "ctx" $) | nindent 4 }}
 spec:

--- a/MosipNexus/helm/nexus-server/templates/hpa.yaml
+++ b/MosipNexus/helm/nexus-server/templates/hpa.yaml
@@ -3,7 +3,7 @@ apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: nexus-api
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "nexus-server.labels" (dict "name" "nexus-api" "ctx" $) | nindent 4 }}
 spec:
   scaleTargetRef:

--- a/MosipNexus/helm/nexus-server/templates/ingress.yaml
+++ b/MosipNexus/helm/nexus-server/templates/ingress.yaml
@@ -3,7 +3,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: nexus-api
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "nexus-server.labels" (dict "name" "nexus-api" "ctx" $) | nindent 4 }}
   annotations: {{- toYaml .Values.api.routing.ingress.annotations | nindent 4 }}
 spec:

--- a/MosipNexus/helm/nexus-server/templates/initial-ingest-job.yaml
+++ b/MosipNexus/helm/nexus-server/templates/initial-ingest-job.yaml
@@ -18,7 +18,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: nexus-initial-ingest
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "nexus-server.labels" (dict "name" "nexus-initial-ingest" "ctx" $) | nindent 4 }}
   annotations:
     "helm.sh/hook": post-install

--- a/MosipNexus/helm/nexus-server/templates/postgres-configmap.yaml
+++ b/MosipNexus/helm/nexus-server/templates/postgres-configmap.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: postgres-init
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "nexus-server.labels" (dict "name" "nexus-postgres" "ctx" $) | nindent 4 }}
 data:
   init.sql: |

--- a/MosipNexus/helm/nexus-server/templates/postgres-pvc.yaml
+++ b/MosipNexus/helm/nexus-server/templates/postgres-pvc.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: postgres-data
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "nexus-server.labels" (dict "name" "nexus-postgres" "ctx" $) | nindent 4 }}
 spec:
   accessModes:

--- a/MosipNexus/helm/nexus-server/templates/postgres-service.yaml
+++ b/MosipNexus/helm/nexus-server/templates/postgres-service.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: nexus-postgres
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "nexus-server.labels" (dict "name" "nexus-postgres" "ctx" $) | nindent 4 }}
 spec:
   selector: {{- include "nexus-server.selectorLabels" (dict "name" "nexus-postgres") | nindent 4 }}

--- a/MosipNexus/helm/nexus-server/templates/postgres-statefulset.yaml
+++ b/MosipNexus/helm/nexus-server/templates/postgres-statefulset.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: nexus-postgres
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "nexus-server.labels" (dict "name" "nexus-postgres" "ctx" $) | nindent 4 }}
 spec:
   serviceName: nexus-postgres

--- a/MosipNexus/helm/nexus-server/templates/prometheusrule.yaml
+++ b/MosipNexus/helm/nexus-server/templates/prometheusrule.yaml
@@ -3,7 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   name: nexus-alerts
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "nexus-server.labels" (dict "name" "nexus-api" "ctx" $) | nindent 4 }}
     {{- if .Values.metrics.prometheusRule.additionalLabels }}
     {{- toYaml .Values.metrics.prometheusRule.additionalLabels | nindent 4 }}
@@ -15,17 +15,17 @@ spec:
       rules:
         - alert: NexusUpdaterFailed
           expr: |
-            kube_job_failed{namespace="{{ .Values.namespace }}", job_name=~"nexus-updater-.*", condition=~"true|unknown"} > 0
+            kube_job_failed{namespace="{{ .Release.Namespace }}", job_name=~"nexus-updater-.*", condition=~"true|unknown"} > 0
           for: 5m
           labels:
             severity: critical
           annotations:
             summary: "nexus-updater CronJob failed"
-            description: "The nightly knowledge update job has failed. Check logs: kubectl logs -n {{ .Values.namespace }} job/{{ "{{ $labels.job_name }}" }}"
+            description: "The nightly knowledge update job has failed. Check logs: kubectl logs -n {{ .Release.Namespace }} job/{{ "{{ $labels.job_name }}" }}"
 
         - alert: NexusBackupFailed
           expr: |
-            kube_job_failed{namespace="{{ .Values.namespace }}", job_name=~"nexus-db-backup-.*", condition=~"true|unknown"} > 0
+            kube_job_failed{namespace="{{ .Release.Namespace }}", job_name=~"nexus-db-backup-.*", condition=~"true|unknown"} > 0
           for: 5m
           labels:
             severity: warning
@@ -37,8 +37,8 @@ spec:
       rules:
         - alert: NexusApiHighMemory
           expr: |
-            container_memory_working_set_bytes{namespace="{{ .Values.namespace }}", container="nexus-api"}
-            / container_spec_memory_limit_bytes{namespace="{{ .Values.namespace }}", container="nexus-api"}
+            container_memory_working_set_bytes{namespace="{{ .Release.Namespace }}", container="nexus-api"}
+            / container_spec_memory_limit_bytes{namespace="{{ .Release.Namespace }}", container="nexus-api"}
             > 0.85
           for: 10m
           labels:
@@ -49,7 +49,7 @@ spec:
 
         - alert: NexusApiRestarting
           expr: |
-            increase(kube_pod_container_status_restarts_total{namespace="{{ .Values.namespace }}", container="nexus-api"}[1h]) > 2
+            increase(kube_pod_container_status_restarts_total{namespace="{{ .Release.Namespace }}", container="nexus-api"}[1h]) > 2
           for: 0m
           labels:
             severity: warning
@@ -59,7 +59,7 @@ spec:
 
         - alert: NexusApiDown
           expr: |
-            kube_deployment_status_replicas_available{namespace="{{ .Values.namespace }}", deployment="nexus-api"} == 0
+            kube_deployment_status_replicas_available{namespace="{{ .Release.Namespace }}", deployment="nexus-api"} == 0
           for: 2m
           labels:
             severity: critical
@@ -71,8 +71,8 @@ spec:
       rules:
         - alert: NexusPostgresDown
           expr: |
-            kube_deployment_status_replicas_available{namespace="{{ .Values.namespace }}", deployment="nexus-postgres"} == 0
-            or kube_statefulset_status_replicas_ready{namespace="{{ .Values.namespace }}", statefulset="nexus-postgres"} == 0
+            kube_deployment_status_replicas_available{namespace="{{ .Release.Namespace }}", deployment="nexus-postgres"} == 0
+            or kube_statefulset_status_replicas_ready{namespace="{{ .Release.Namespace }}", statefulset="nexus-postgres"} == 0
           for: 2m
           labels:
             severity: critical

--- a/MosipNexus/helm/nexus-server/templates/service-account.yaml
+++ b/MosipNexus/helm/nexus-server/templates/service-account.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "nexus-server.serviceAccountName" . }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "nexus-server.labels" (dict "name" "nexus-api" "ctx" $) | nindent 4 }}
   annotations: {{- include "nexus-server.annotations" (dict "ctx" $) | nindent 4 }}
 {{- end }}

--- a/MosipNexus/helm/nexus-server/templates/service.yaml
+++ b/MosipNexus/helm/nexus-server/templates/service.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: nexus-api
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "nexus-server.labels" (dict "name" "nexus-api" "ctx" $) | nindent 4 }}
   annotations: {{- include "nexus-server.annotations" (dict "ctx" $) | nindent 4 }}
 spec:

--- a/MosipNexus/helm/nexus-server/templates/servicemonitor.yaml
+++ b/MosipNexus/helm/nexus-server/templates/servicemonitor.yaml
@@ -3,7 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: nexus-api
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "nexus-server.labels" (dict "name" "nexus-api" "ctx" $) | nindent 4 }}
     {{- if .Values.metrics.serviceMonitor.additionalLabels }}
     {{- toYaml .Values.metrics.serviceMonitor.additionalLabels | nindent 4 }}

--- a/MosipNexus/helm/nexus-server/templates/updater-cronjob.yaml
+++ b/MosipNexus/helm/nexus-server/templates/updater-cronjob.yaml
@@ -1,11 +1,11 @@
 {{- if .Values.updater.enabled }}
 # Trigger a manual first run after install:
-#   kubectl create job --from=cronjob/nexus-updater nexus-updater-init -n {{ .Values.namespace }}
+#   kubectl create job --from=cronjob/nexus-updater nexus-updater-init -n {{ .Release.Namespace }}
 apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: nexus-updater
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "nexus-server.labels" (dict "name" "nexus-updater" "ctx" $) | nindent 4 }}
 spec:
   schedule: {{ .Values.updater.schedule | quote }}

--- a/MosipNexus/helm/nexus-server/templates/updater-pvc.yaml
+++ b/MosipNexus/helm/nexus-server/templates/updater-pvc.yaml
@@ -7,7 +7,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: nexus-data
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "nexus-server.labels" (dict "name" "nexus-updater" "ctx" $) | nindent 4 }}
 spec:
   accessModes: {{- toYaml .Values.updater.pvc.accessModes | nindent 4 }}

--- a/MosipNexus/helm/nexus-server/templates/virtualservice.yaml
+++ b/MosipNexus/helm/nexus-server/templates/virtualservice.yaml
@@ -3,7 +3,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
   name: nexus-api
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "nexus-server.labels" (dict "name" "nexus-api" "ctx" $) | nindent 4 }}
   annotations: {{- include "nexus-server.annotations" (dict "ctx" $) | nindent 4 }}
 spec:

--- a/MosipNexus/helm/nexus-server/values.yaml
+++ b/MosipNexus/helm/nexus-server/values.yaml
@@ -1,12 +1,11 @@
 ## MOSIP Nexus Server — Helm values
 ## Faithful, values-driven equivalent of the raw manifests in ../../k8s/.
 ## See README.md for the full parameter reference.
-
-## Namespace this release's resources are created in. Helm does not manage
-## the Namespace object itself (best practice) — create it with:
-##   helm install nexus-server . --namespace mosip-nexus --create-namespace
 ##
-namespace: mosip-nexus
+## Deployed into whatever namespace `helm install`/`upgrade -n <ns>` targets —
+## every template uses .Release.Namespace, not a separate values-driven
+## namespace field, so there's exactly one place that decides where resources
+## land (matching the pattern used by other MOSIP module charts, e.g. kernel).
 
 ## Default StorageClass for every PVC this chart creates (postgres, updater,
 ## backup). Leave "" to use the cluster's default StorageClass. Each PVC's own

--- a/MosipNexus/helm/nexus-ui/Chart.yaml
+++ b/MosipNexus/helm/nexus-ui/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nexus-ui
 description: Helm chart for the MOSIP Nexus UI (React + nginx)
 type: application
-version: 1.0.0
+version: 1.0.1
 appVersion: "1.0.0"
 home: https://docs.mosip.io
 keywords:

--- a/MosipNexus/helm/nexus-ui/Chart.yaml
+++ b/MosipNexus/helm/nexus-ui/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nexus-ui
 description: Helm chart for the MOSIP Nexus UI (React + nginx)
 type: application
-version: 1.0.1
+version: 1.0.0
 appVersion: "1.0.0"
 home: https://docs.mosip.io
 keywords:

--- a/MosipNexus/helm/nexus-ui/README.md
+++ b/MosipNexus/helm/nexus-ui/README.md
@@ -52,9 +52,10 @@ independently per chart if you need to:
 
 ## Key parameters
 
+Namespace isn't a chart parameter — every resource uses `.Release.Namespace`, so install this into the same namespace as nexus-server (`-n <ns>`, same as it was installed with).
+
 | Parameter | Default | Description |
 | --- | --- | --- |
-| `namespace` | `mosip-nexus` | Must match the nexus-server release's namespace |
 | `image.repository` / `image.tag` | `nexus-ui` / `v1.0.0` | UI image |
 | `routing.mode` | `istio` | `istio` or `nginx` |
 | `routing.ingress.host` | `nexus.mosip.net` | Used when `routing.mode: nginx` |

--- a/MosipNexus/helm/nexus-ui/templates/NOTES.txt
+++ b/MosipNexus/helm/nexus-ui/templates/NOTES.txt
@@ -1,4 +1,4 @@
-MOSIP Nexus UI ({{ .Chart.Name }} {{ .Chart.Version }}) has been installed into namespace "{{ .Values.namespace }}".
+MOSIP Nexus UI ({{ .Chart.Name }} {{ .Chart.Version }}) has been installed into namespace "{{ .Release.Namespace }}".
 
 {{- if eq .Values.routing.mode "istio" }}
 
@@ -12,8 +12,8 @@ Routing: nginx Ingress
 
 The UI's nginx proxies same-origin /api/* to the "nexus-api" Service — make
 sure helm/nexus-server is installed in the same namespace
-("{{ .Values.namespace }}") first.
+("{{ .Release.Namespace }}") first.
 
 Check it's up:
-  kubectl port-forward -n {{ .Values.namespace }} svc/nexus-ui 8501:{{ .Values.service.port }}
+  kubectl port-forward -n {{ .Release.Namespace }} svc/nexus-ui 8501:{{ .Values.service.port }}
   curl http://localhost:8501/healthz

--- a/MosipNexus/helm/nexus-ui/templates/deployment.yaml
+++ b/MosipNexus/helm/nexus-ui/templates/deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: nexus-ui
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "nexus-ui.labels" . | nindent 4 }}
   annotations: {{- include "nexus-ui.annotations" . | nindent 4 }}
 spec:

--- a/MosipNexus/helm/nexus-ui/templates/gateway.yaml
+++ b/MosipNexus/helm/nexus-ui/templates/gateway.yaml
@@ -6,7 +6,7 @@ apiVersion: networking.istio.io/v1
 kind: Gateway
 metadata:
   name: nexus-ui
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "nexus-ui.labels" . | nindent 4 }}
   annotations: {{- include "nexus-ui.annotations" . | nindent 4 }}
 spec:

--- a/MosipNexus/helm/nexus-ui/templates/ingress.yaml
+++ b/MosipNexus/helm/nexus-ui/templates/ingress.yaml
@@ -3,7 +3,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: nexus-ui
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "nexus-ui.labels" . | nindent 4 }}
   annotations: {{- toYaml .Values.routing.ingress.annotations | nindent 4 }}
 spec:

--- a/MosipNexus/helm/nexus-ui/templates/service-account.yaml
+++ b/MosipNexus/helm/nexus-ui/templates/service-account.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "nexus-ui.serviceAccountName" . }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "nexus-ui.labels" . | nindent 4 }}
   annotations: {{- include "nexus-ui.annotations" . | nindent 4 }}
 {{- end }}

--- a/MosipNexus/helm/nexus-ui/templates/service.yaml
+++ b/MosipNexus/helm/nexus-ui/templates/service.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: nexus-ui
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "nexus-ui.labels" . | nindent 4 }}
   annotations: {{- include "nexus-ui.annotations" . | nindent 4 }}
 spec:

--- a/MosipNexus/helm/nexus-ui/templates/virtualservice.yaml
+++ b/MosipNexus/helm/nexus-ui/templates/virtualservice.yaml
@@ -3,14 +3,14 @@ apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
   name: nexus-ui
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "nexus-ui.labels" . | nindent 4 }}
   annotations: {{- include "nexus-ui.annotations" . | nindent 4 }}
 spec:
   hosts: {{- toYaml .Values.routing.istio.hosts | nindent 4 }}
   gateways:
     {{- if .Values.routing.istio.createGateway }}
-    - {{ .Values.namespace }}/nexus-ui
+    - {{ .Release.Namespace }}/nexus-ui
     {{- else }}
     - {{ .Values.routing.istio.gateway }}
     {{- end }}

--- a/MosipNexus/helm/nexus-ui/values.yaml
+++ b/MosipNexus/helm/nexus-ui/values.yaml
@@ -1,9 +1,10 @@
 ## MOSIP Nexus UI — Helm values
 ## Faithful, values-driven equivalent of the raw manifests in ../../k8s/.
 ## Prerequisite: install helm/nexus-server first (same namespace) — the
-## UI's nginx proxies same-origin /api/* to the "nexus-api" Service.
-
-namespace: mosip-nexus
+## UI's nginx proxies same-origin /api/* to the "nexus-api" Service. Deployed
+## into whatever namespace `helm install`/`upgrade -n <ns>` targets — see
+## nexus-server/README.md for why this chart uses .Release.Namespace instead
+## of a separate values-driven namespace field.
 
 commonLabels: {}
 commonAnnotations: {}


### PR DESCRIPTION
## Summary
Both charts had their own `values.yaml` `namespace` key, independently threaded through every template's `metadata.namespace`, completely disconnected from the `-n`/`--namespace` flag passed to `helm install`/`upgrade`. `install.sh` always kept these in sync by construction (same `$NS` var for `kubectl create ns` and `helm -n`), but editing `$NS` without also overriding `--set namespace=...` reproduces exactly what just happened on the live cluster: Helm's own release bookkeeping lives under the new namespace while every actual resource still targets the old (now-nonexistent) one, and the apply fails with `namespaces "X" not found` for every single resource.

Other MOSIP module charts (e.g. `kernel`: `helm -n $NS install ...`, no values-file namespace field at all) don't have this problem — they use Helm's built-in `.Release.Namespace`, which is automatically and always exactly whatever `-n`/`--namespace` was passed, so there's no second value that can drift out of sync. This PR matches that pattern: replaces every `.Values.namespace` reference with `.Release.Namespace` across both charts' templates, and drops the now-unused `namespace` key from both `values.yaml` files. `install.sh` needs no changes — it already passes `-n "$NS"` to `helm upgrade --install`, which is now the only thing that determines where resources land.

## Verification
Real `kattu`/`mosip-helm-gh-pages` toolchain (`ct` + `yamale` via `uv`, since `pip`/`venv` aren't available in this sandbox):
- `helm lint` — clean
- `helm template --namespace nexus` (a namespace *other than* the old `values.yaml` default) — every resource correctly follows it; this is the actual regression test for the bug this fixes
- `ct lint --validate-maintainers` against the real `chart-schema.yaml`/`lintconf.yaml` — both charts pass
- `yamale` against the real `health-check-schema.yaml` on rendered `Deployment`/`StatefulSet` manifests — both charts pass

https://claude.ai/code/session_01A5KE4fZxHqbeiDaUJenSfU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Helm guidance to clarify that resources deploy to the Helm release namespace.
  * Removed obsolete namespace configuration references.

* **Bug Fixes**
  * Ensured Nexus server and UI resources, operational jobs, monitoring alerts, and generated commands consistently use the selected Helm release namespace.
  * Improved deployment consistency when installing or upgrading charts with a custom namespace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->