### PR TITLE
#10670: Add AGENTS.md for AI coding assistant guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,175 @@
+# AGENTS.md
+
+## Repository Overview
+
+`mosip-labs` is MOSIP's collection of experimental and incubating projects —
+proof-of-concepts and integration demos built on top of the core MOSIP
+(Modular Open Source Identity Platform) stack. Unlike most MOSIP repos, this
+one is a **grab-bag of independent projects**, not a single service or a
+family of tightly coupled modules. Each top-level project has its own stack,
+its own build tooling, and its own lifecycle. There is no shared build file,
+no shared dependency manifest, and no shared runtime at the repo root.
+
+Because the projects are unrelated, this file is a hub: read it for
+repo-wide facts (CI, branching, PR process), then follow the link to the
+project you're actually touching for build/run/test detail.
+
+## Projects in this repo
+
+| Project | What it is | Stack | Guide |
+| --- | --- | --- | --- |
+| `MosipNexus/` | Production-grade RAG knowledge assistant for MOSIP/Inji docs, with a React UI and MCP (Claude Desktop) support | Python 3.13 FastAPI + React 19/TypeScript/Vite | [`MosipNexus/AGENTS.md`](MosipNexus/AGENTS.md) |
+| `github-activity-tracker/` | Dashboard that syncs and visualizes GitHub org activity (commits, PRs, reviews, issues) across MOSIP repos | Node.js/Express backend + React/Vite frontend, Postgres | [`github-activity-tracker/AGENTS.md`](github-activity-tracker/AGENTS.md) |
+| `ussd-proxy-service/` | Bridge service between a USSD gateway (Africa's Talking) and MOSIP Resident Services, for basic-phone identity access | Java 8, Spring Boot 2.3 | [`ussd-proxy-service/AGENTS.md`](ussd-proxy-service/AGENTS.md) |
+
+`MosipNexus` already carries its own `AGENTS.md` tree (root plus
+`Server/AGENTS.md` and `UI/AGENTS.md`) — this root file does not duplicate
+that content, only points to it.
+
+No project is empty or a placeholder; all three have real source, build
+files, and (for `github-activity-tracker` and `MosipNexus`) working CI. None
+looked abandoned at the time this file was written, though `ussd-proxy-service`
+is visibly older (Java 8, Spring Boot 2.3, no automated tests) and gets far
+less activity than the other two — treat changes there conservatively.
+
+## Technology Stack
+
+There is no repo-wide stack — each project picks its own (see the table
+above). The only shared surface is:
+
+- **CI**: GitHub Actions, defined once at `.github/workflows/` (repo root),
+  not per-project.
+- **Helm charts**: `github-activity-tracker/helm/` and `MosipNexus/helm/`
+  are published to `https://mosip.github.io/mosip-helm`. `ussd-proxy-service`
+  has no Helm chart — it ships a plain Dockerfile only.
+
+## Build & Test Commands
+
+There is no root-level build command — build each project from inside its
+own directory. See the per-project `AGENTS.md` files linked above for exact
+commands. Summary:
+
+- `MosipNexus/Server` — `uv sync` / `pip install -r requirements.txt`, run
+  via `./run.sh` or `run.bat`. `MosipNexus/UI` — `npm install`, `npm run dev`
+  / `npm run build`. Full detail in `MosipNexus/AGENTS.md`.
+- `github-activity-tracker/backend` — `npm install`, `npm start` / `npm run
+  dev`. `github-activity-tracker/frontend` — `npm install`, `npm run dev` /
+  `npm run build`. Detail in `github-activity-tracker/AGENTS.md`.
+- `ussd-proxy-service` — Maven (`mvn clean install`, `mvn spring-boot:run`).
+  Detail in `ussd-proxy-service/AGENTS.md`.
+
+## Configuration
+
+Every project keeps its own secrets and environment files local to its own
+directory — there is no shared `.env` or config file at the repo root.
+Never commit real tokens, API keys, or database passwords in place of the
+`*.env.example` / `*-values.yaml` placeholders. See each project's guide for
+which files hold local secrets (this matters more than usual here: as of
+this writing, `ussd-proxy-service/src/main/resources/application.properties`
+already has non-placeholder-looking values checked into version control —
+do not copy that pattern into new code, and do not add further real
+credentials to that file).
+
+## Project Structure Notes
+
+```text
+mosip-labs/
+├── .github/workflows/          # All CI for every project lives here, not per-project
+├── MosipNexus/                 # RAG assistant — see MosipNexus/AGENTS.md
+│   ├── Server/                 # FastAPI backend
+│   ├── UI/                     # React frontend
+│   └── helm/                   # nexus-server + nexus-ui charts
+├── github-activity-tracker/    # GitHub activity dashboard — see github-activity-tracker/AGENTS.md
+│   ├── backend/                # Express API + Postgres migrations
+│   ├── frontend/                # React/Vite dashboard
+│   └── helm/                   # gh-tracker-service + gh-tracker-ui charts
+└── ussd-proxy-service/         # USSD-to-MOSIP bridge — see ussd-proxy-service/AGENTS.md
+    └── src/main/java/...       # Spring Boot app (Maven, single module)
+```
+
+CI workflows are keyed by path, and the paths matter:
+
+- `.github/workflows/chart-lint-publish.yml` lints/publishes only
+  `github-activity-tracker/helm/**` changes.
+- `.github/workflows/mosip-nexus-chart-lint-publish.yml` lints/publishes
+  only `MosipNexus/helm/**` changes.
+- `.github/workflows/push-trigger.yml` ("Maven Package upon a push") builds
+  and Docker-packages `github-activity-tracker/backend`,
+  `github-activity-tracker/frontend`, `MosipNexus/Server`, and
+  `MosipNexus/UI` on every push to `master`, `develop`, `1.*`, `MOSIP*`, or
+  `release*` — it has **no path filter**, so it runs on every such push
+  regardless of which project changed. It does not build or package
+  `ussd-proxy-service` at all — that project has no CI in this repo.
+- `.github/workflows/update-reports.yml` is unrelated to any of the three
+  projects above: a scheduled job (weekdays, cron) that runs against a
+  separate `reporting` branch to refresh CSV/XLSX/Google Sheet exports via
+  MinIO. It is not part of the normal PR/build flow for `develop`.
+
+## Development Workflow
+
+1. Work inside the one project directory your change belongs to. Do not
+   introduce cross-project imports or shared code between `MosipNexus`,
+   `github-activity-tracker`, and `ussd-proxy-service` — they are
+   intentionally independent and deployed separately.
+2. Branch from `develop` (the active integration branch for this repo, not
+   `master`).
+3. Build and, where the project has them, run tests locally before opening
+   a PR — see the per-project guide for exact commands. `ussd-proxy-service`
+   has no automated test suite in this repo; verify changes to it manually.
+4. If you touch a Helm chart under `github-activity-tracker/helm/` or
+   `MosipNexus/helm/`, expect the matching `chart-lint-publish` workflow to
+   run lint automatically on your PR (publish only happens on `push`/
+   `release`, never on `pull_request`).
+
+## Pull Request Guidelines
+
+- Target the `develop` branch.
+- Keep PRs scoped to one project — a PR that touches both
+  `github-activity-tracker` and `ussd-proxy-service`, for example, is harder
+  to review and to roll back independently.
+- Reference the tracking issue in the PR description.
+- If your change affects a Helm chart's public interface (new required
+  value, changed default), call that out explicitly in the PR body — chart
+  consumers read `values.yaml` as the contract.
+
+## Repository-Specific Considerations
+
+- **This is not a monorepo in the usual sense.** Resist the instinct to
+  factor out "shared" utilities between the three projects; none of the
+  existing MOSIP conventions here assume that, and CI, Helm charts, and
+  versioning are all per-project.
+- **`ussd-proxy-service` is legacy relative to the other two**: Java 8,
+  Spring Boot 2.3.12 (from 2020), no CI wiring in this repo, no test
+  directory. Treat it as a maintenance/compliance surface, not a place to
+  build new patterns — match its existing style rather than modernizing it
+  in the same PR as a functional change.
+- **`MosipNexus` already has thorough `AGENTS.md` coverage** (root +
+  `Server/` + `UI/`); read those before making assumptions about it instead
+  of re-deriving them from source.
+
+## Agent rules
+
+### Do
+
+1. Read the project-specific `AGENTS.md` (or `MosipNexus/Server` /
+   `MosipNexus/UI` guide) before editing inside that project.
+2. Keep changes scoped to a single project per PR.
+3. Target `develop` when branching and opening PRs.
+4. Use the placeholder/example env and values files (`*.env.example`,
+   `*-values.yaml`) as the template for new configuration — never commit
+   real secrets.
+5. Verify claims about CI, build commands, or config against the actual
+   workflow/build files in this repo rather than assuming another MOSIP
+   repo's conventions apply here.
+
+### Do not
+
+1. Do not add shared code, shared build tooling, or cross-imports between
+   `MosipNexus`, `github-activity-tracker`, and `ussd-proxy-service`.
+2. Do not copy the checked-in, non-placeholder-looking values in
+   `ussd-proxy-service/src/main/resources/application.properties` into new
+   files, and do not add further real credentials to that file.
+3. Do not assume `ussd-proxy-service` has CI, a Helm chart, or an automated
+   test suite in this repo — it has none of the three.
+4. Do not target `master` for PRs; this repo's active integration branch is
+   `develop`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,7 +155,10 @@ CI workflows are keyed by path, and the paths matter:
 
 1. Read the project-specific `AGENTS.md` (or `MosipNexus/Server` /
    `MosipNexus/UI` guide) before editing inside that project.
-2. Keep changes scoped to a single project per PR.
+2. Keep code, build, and deployment changes scoped to a single project
+   per PR. Repository-wide documentation changes, such as coordinated
+   root and project-specific `AGENTS.md` updates, are exempt from this
+   rule.
 3. Target `develop` when branching and opening PRs.
 4. Use the placeholder/example env and values files (`*.env.example`,
    `*-values.yaml`) as the template for new configuration — never commit

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,9 +124,11 @@ CI workflows are keyed by path, and the paths matter:
 ## Pull Request Guidelines
 
 - Target the `develop` branch.
-- Keep PRs scoped to one project — a PR that touches both
-  `github-activity-tracker` and `ussd-proxy-service`, for example, is harder
-  to review and to roll back independently.
+- Keep code, build, and deployment changes scoped to one project — a PR
+  that touches both `github-activity-tracker` and `ussd-proxy-service`,
+  for example, is harder to review and to roll back independently.
+  Repository-wide documentation changes (e.g. updating the root and
+  per-project `AGENTS.md` files together) are exempt from this rule.
 - Reference the tracking issue in the PR description.
 - If your change affects a Helm chart's public interface (new required
   value, changed default), call that out explicitly in the PR body — chart

--- a/github-activity-tracker/AGENTS.md
+++ b/github-activity-tracker/AGENTS.md
@@ -84,9 +84,12 @@ that matches how you're running the project, not both blindly:
   the backend directly with `npm start` outside Docker. Copy to
   `github-activity-tracker/backend/.env`.
 
-`GITHUB_TOKEN` needs `repo` scope (create at
-`https://github.com/settings/tokens`) — required for the sync endpoints to
-call the GitHub API. Backend services read only `RDS_*` variables (not
+`GITHUB_TOKEN` needs only the permissions required by the GitHub API calls
+in `backend/` — these are all read queries (GraphQL requests sent over
+HTTP `POST`, not write operations). Prefer a fine-grained token or GitHub
+App with repository-scoped, read-only permissions instead of the broad
+classic `repo` scope (create at `https://github.com/settings/tokens`).
+Backend services read only `RDS_*` variables (not
 `POSTGRES_*`); the `POSTGRES_*` variables in the root `.env.example` are for
 the Docker Postgres container's own bootstrap, so both sets need to point at
 the same database when running locally via Compose.

--- a/github-activity-tracker/AGENTS.md
+++ b/github-activity-tracker/AGENTS.md
@@ -1,0 +1,185 @@
+# AGENTS.md
+
+Guidance for the `github-activity-tracker` project inside the `mosip-labs`
+monorepo. See [`../AGENTS.md`](../AGENTS.md) for repo-wide conventions
+(branching, CI overview, PR scoping) — this file covers only what's specific
+to this project.
+
+## Repository Overview
+
+`github-activity-tracker` syncs GitHub activity (commits, pull requests,
+reviews, issues) for MOSIP organizations into a Postgres database and
+presents it as a dashboard: per-user stats, leaderboards, team activity
+trends, and role tracking. It is two independently deployable pieces:
+
+- `backend/` — an Express API that talks to the GitHub API and Postgres,
+  and exposes sync + query routes.
+- `frontend/` — a React/Vite dashboard that consumes the backend API.
+
+## Technology Stack
+
+- **Backend**: Node.js, Express 4, `pg` (Postgres client), `axios` (GitHub
+  API calls), `dayjs`/`luxon` for dates. Entry point `backend/app.js`.
+- **Frontend**: React 18 + TypeScript, Vite, Tailwind CSS, Chart.js
+  (`react-chartjs-2`), TanStack Query, `@supabase/supabase-js`,
+  `lucide-react` icons.
+- **Database**: Postgres 16 (`postgres:16-alpine` in Docker Compose), with
+  hand-written SQL migrations under `backend/migrations/`.
+- **Deployment**: Docker (per-component `Dockerfile`), Helm charts under
+  `helm/gh-tracker-service/` and `helm/gh-tracker-ui/`.
+
+## Build & Test Commands
+
+There is no test suite in this project (no `test` script in either
+`package.json`, no test files under `backend/` or `frontend/`). Verify
+changes by running the app locally and exercising the affected routes/UI.
+
+Backend (from `github-activity-tracker/backend/`):
+
+```bash
+npm install
+npm start          # runs `node app.js`
+npm run dev         # runs via nodemon, restarts on change
+npm run migrate     # runs backend/migrations/runMigrations.js
+npm run build        # copies app.js, package*.json, and source dirs into dist/
+```
+
+Frontend (from `github-activity-tracker/frontend/`):
+
+```bash
+npm install
+npm run dev          # Vite dev server
+npm run build         # production build
+npm run lint          # eslint, zero warnings allowed (--max-warnings 0)
+npm run preview       # preview the production build locally
+```
+
+Full stack via Docker Compose (from `github-activity-tracker/`):
+
+```bash
+docker compose up --build
+```
+
+This starts `db` (Postgres), `backend` (port 3000, runs migrations then
+`node app.js`), and `frontend` (served on host port 80, container port
+8080). To run migrations once against an already-running stack without
+restarting the backend:
+
+```bash
+docker compose run --rm migrate
+```
+
+## Configuration
+
+Two `.env.example` files exist and cover different scopes — copy the one
+that matches how you're running the project, not both blindly:
+
+- `github-activity-tracker/.env.example` — the **root** file, consumed by
+  `docker-compose.yml` (`RDS_*` DB settings, `GITHUB_TOKEN`, `GITHUB_ORG`,
+  `USER_ROLES`, `ALLOWED_ORIGINS`, plus commented `POSTGRES_*` values for
+  the Postgres container itself). Copy to `github-activity-tracker/.env`
+  for `docker compose up`.
+- `github-activity-tracker/backend/.env.example` — the same `RDS_*` /
+  `GITHUB_TOKEN` / `GITHUB_ORG` / `USER_ROLES` variables, scoped for running
+  the backend directly with `npm start` outside Docker. Copy to
+  `github-activity-tracker/backend/.env`.
+
+`GITHUB_TOKEN` needs `repo` scope (create at
+`https://github.com/settings/tokens`) — required for the sync endpoints to
+call the GitHub API. Backend services read only `RDS_*` variables (not
+`POSTGRES_*`); the `POSTGRES_*` variables in the root `.env.example` are for
+the Docker Postgres container's own bootstrap, so both sets need to point at
+the same database when running locally via Compose.
+
+Helm deploys read from `deploy/gh-tracker-values.yaml` and
+`deploy/gh-tracker-ui-values.yaml` — `deploy/README.md` explicitly warns to
+fill in the required variables in both files before running `./install.sh`.
+
+## Project Structure Notes
+
+```text
+github-activity-tracker/
+├── backend/
+│   ├── app.js                 # Express entry point
+│   ├── routes/                 # One file per sync/query endpoint group
+│   ├── services/                # Business logic behind each route
+│   ├── migrations/              # Numbered SQL migrations + runMigrations.js
+│   ├── config/                  # errorCodes.js, excludedGitHubLogins.js, syncConfig.js
+│   ├── db/                      # dbPool.js, initLookupTables.js
+│   └── utils/                    # githubClient.js, userRoleSql.js
+├── frontend/
+│   └── src/
+│       ├── components/          # Dashboard widgets (charts, cards, tables)
+│       └── lib/                  # api.ts, hooks.ts, organizations.ts, periods.ts
+├── deploy/                      # install.sh / restart.sh / delete.sh wrapping the Helm charts
+├── helm/
+│   ├── gh-tracker-service/       # Backend chart
+│   └── gh-tracker-ui/            # Frontend chart
+└── docker-compose.yml
+```
+
+Migrations are plain numbered SQL files (`001_...` through `009_...` as of
+this writing) run in order by `backend/migrations/runMigrations.js` — add a
+new migration as the next number, don't edit an already-applied one.
+
+## Development Workflow
+
+1. Start Postgres (via `docker compose up db` or an external instance) and
+   point `RDS_*` at it.
+2. Run `npm run migrate` in `backend/` before starting the API for the
+   first time, or after adding a new migration file.
+3. Run backend (`npm run dev`) and frontend (`npm run dev`) separately for
+   local iteration, or use `docker compose up --build` for the full stack.
+4. Run `npm run lint` in `frontend/` before opening a PR — the CI-equivalent
+   check has zero tolerance for warnings (`--max-warnings 0`).
+
+## Pull Request Guidelines
+
+- Target `develop` (see repo-wide [`../AGENTS.md`](../AGENTS.md)).
+- If you change `backend/migrations/`, add a new file rather than editing
+  an existing one — migrations already applied elsewhere must stay
+  immutable.
+- If you change `helm/gh-tracker-service/` or `helm/gh-tracker-ui/`,
+  mention it in the PR body — `.github/workflows/chart-lint-publish.yml`
+  lints those paths on every PR (publish to `gh-pages` only happens on
+  `push`/`release`, not on `pull_request`).
+- CI builds and Docker-packages both `backend/` and `frontend/` on pushes to
+  `master`, `develop`, `1.*`, `MOSIP*`, and `release*` via
+  `.github/workflows/push-trigger.yml` — there's no separate test gate, so
+  a build failure there is the first signal something's broken.
+
+## Repository-Specific Considerations
+
+- The frontend's own `README.md` is the generic Vite/React template
+  boilerplate — it has no project-specific instructions; use this file and
+  the root `AGENTS.md` instead.
+- `frontend/package.json` lists `pg` (a Postgres client) as a frontend
+  dependency even though the frontend talks to the backend over HTTP, not
+  directly to the database — don't take this as license to add direct DB
+  access from frontend code; it should still go through `backend/`'s API.
+- `GITHUB_ORG` and `USER_ROLES` are comma-separated lists read at backend
+  startup (`USER_ROLES` seeds the `user_roles` table) — changing them
+  requires a backend restart, not just a config file edit.
+
+## Agent rules
+
+### Do
+
+1. Copy the `.env.example` that matches how you're running the project
+   (root for Docker Compose, `backend/.env.example` for running the API
+   directly) and fill in real values only in the untracked `.env` copy.
+2. Add new SQL migrations as new numbered files under `backend/migrations/`.
+3. Run `npm run lint` in `frontend/` before committing frontend changes.
+4. Route all data access through `backend/`'s API from frontend code.
+
+### Do not
+
+1. Do not edit an already-numbered migration file that may already be
+   applied elsewhere — add a new one instead.
+2. Do not commit a real `GITHUB_TOKEN`, RDS password, or Helm
+   `*-values.yaml` with production values filled in.
+3. Do not add direct database access from `frontend/` code just because
+   `pg` happens to be listed as a dependency there.
+4. Do not assume there's a test suite to run — verify changes manually
+   against the running app; none of `backend/` or `frontend/` has automated
+   tests as of this writing.

--- a/ussd-proxy-service/AGENTS.md
+++ b/ussd-proxy-service/AGENTS.md
@@ -70,10 +70,12 @@ startup script — it's a pair of `curl` calls against an already-running
 instance that register the USSD setup and a test partner:
 
 ```bash
+# Local-only smoke test — do not run against a shared/production endpoint.
 curl -X POST "http://localhost/AT/ussd/setup" -H "accept: */*"
+PARTNER_KEY="${PARTNER_KEY:?Set PARTNER_KEY for this test}"
 curl -X POST "http://localhost/ussd/partner/" -H "accept: */*" \
   -H "Content-Type: application/json" \
-  -d '{"partnerId":"1000","partnerUrl":"http://localhost:8080/credentials/","partnerKey":"abc123"}'
+  -d "{\"partnerId\":\"1000\",\"partnerUrl\":\"http://localhost:8080/credentials/\",\"partnerKey\":\"${PARTNER_KEY}\"}"
 ```
 
 ## Configuration
@@ -84,8 +86,11 @@ settings, the MOSIP `mosip.appId` / `mosip.clientId` / `mosip.clientSecret`
 / `mosip.baseUrl` used to call MOSIP APIs, and the H2 datasource.
 
 **This file, as checked into the repo, already contains non-placeholder-
-looking values** — an `emnify.apikey` JWT and a `mosip.clientSecret` — not
-just example/blank placeholders. Treat that as a known issue in this
+looking values** — a live-looking `emnify.apikey` JWT and a
+`mosip.clientSecret` — not just example/blank placeholders. Treat both as
+compromised, since this is a public repo: they should be revoked/rotated
+by whoever owns them, and removed from the tracked file (and ideally from
+git history) rather than left in place. This is a known issue in this
 project, not a pattern to follow: do not add further real credentials to
 `application.properties`, and if you're setting up your own environment,
 override these via Spring's usual mechanisms (environment variables,
@@ -138,8 +143,10 @@ and, if a new state needs custom logic, add a handler class under
    `application.properties`, which point at specific dev/sandbox instances
    and a real-looking secret.
 2. `mvn clean install` to build; `mvn spring-boot:run` (or run the built
-   jar) to start the service on port 80 (H2 file DB is created alongside
-   the jar as `./USSDDataBase`).
+   jar) to start the service on port 80. `spring.datasource.url=jdbc:h2:file:./USSDDataBase`
+   is relative to the JVM's **current working directory**, not the jar's
+   location — running `java -jar target/*.jar` from the repo root creates
+   `./USSDDataBase` there, not inside `target/`.
 3. Use the `curl` calls in `run.sh` to register the USSD setup and a test
    partner before exercising the USSD flow end to end.
 4. There's no automated test suite — validate state-machine or handler

--- a/ussd-proxy-service/AGENTS.md
+++ b/ussd-proxy-service/AGENTS.md
@@ -85,17 +85,17 @@ configuration: server port (`server.port=80`), Emnify callback/API
 settings, the MOSIP `mosip.appId` / `mosip.clientId` / `mosip.clientSecret`
 / `mosip.baseUrl` used to call MOSIP APIs, and the H2 datasource.
 
-**This file, as checked into the repo, already contains non-placeholder-
-looking values** — a live-looking `emnify.apikey` JWT and a
-`mosip.clientSecret` — not just example/blank placeholders. Treat both as
-compromised, since this is a public repo: they should be revoked/rotated
-by whoever owns them, and removed from the tracked file (and ideally from
-git history) rather than left in place. This is a known issue in this
-project, not a pattern to follow: do not add further real credentials to
-`application.properties`, and if you're setting up your own environment,
-override these via Spring's usual mechanisms (environment variables,
-`-D` system properties before `-jar`, or a profile-specific properties
-file) rather than editing the committed values in place.
+`emnify.apikey` and `mosip.clientSecret` were previously committed here as
+literal, live-looking values. They are now `${EMNIFY_APIKEY:}` /
+`${MOSIP_CLIENT_SECRET:}` — set the actual value via the matching
+environment variable (or a `-D` system property before `-jar`, or a
+profile-specific properties file). **The old literal values remain in
+this repo's git history and must still be treated as compromised** —
+whoever owns them needs to revoke/rotate both, and ideally purge them
+from history (e.g. via `git filter-repo`) since removing them from the
+current file does not remove them from prior commits. Do not add further
+real credentials to `application.properties` — commented-out example
+lines use a `<set via ENV_VAR>` placeholder for the same reason.
 
 There is no separate `.env.example` or secrets-management convention in
 this project — it's all in the one properties file.

--- a/ussd-proxy-service/AGENTS.md
+++ b/ussd-proxy-service/AGENTS.md
@@ -1,0 +1,198 @@
+# AGENTS.md
+
+Guidance for the `ussd-proxy-service` project inside the `mosip-labs`
+monorepo. See [`../AGENTS.md`](../AGENTS.md) for repo-wide conventions
+(branching, CI overview, PR scoping) — this file covers only what's specific
+to this project.
+
+## Repository Overview
+
+`ussd-proxy-service` is a bridge between a USSD (Unstructured Supplementary
+Service Data) gateway and MOSIP Resident Services, so that people on basic
+phones — no smartphone or internet needed — can check RID/UIN status, view
+auth history, lock/unlock their UIN, and manage credentials over a USSD
+menu. The current implementation targets Africa's Talking as the USSD
+aggregator (tested against their sandbox and phone simulator), with an
+Emnify integration also present in the code (`org.mosip.ussd.emnify`
+package) for SMS/USSD push via a different provider.
+
+Menu flow is driven by a small state-machine engine defined in this
+project (`org.mosip.ussd.sm`), not a general-purpose library — states,
+transitions, and handlers are all wired through
+`src/main/resources/statemachine/sm.json` and per-language menu files.
+
+## Technology Stack
+
+- **Language**: Java 8 (`java.version=1.8` in `pom.xml`).
+- **Framework**: Spring Boot 2.3.12.RELEASE (`spring-boot-starter-web`,
+  `spring-boot-starter-data-jpa`, `spring-boot-starter-batch`).
+- **Database**: H2, both file-backed (`spring.datasource.url=jdbc:h2:file:./USSDDataBase`)
+  by default in `application.properties`.
+- **API docs**: springdoc-openapi-ui (Swagger).
+- **HTTP clients**: Retrofit2, Apache HttpClient, OkHttp logging
+  interceptor — used to call MOSIP Resident/IDA APIs and the
+  Emnify/Africa's Talking gateways.
+- **Build**: Maven (`pom.xml`, no Maven wrapper checked in — a local `mvn`
+  install is required).
+
+## Build & Test Commands
+
+There is no test source directory in this project and no test dependency
+declared in `pom.xml` — there is nothing for `mvn test` to run. Verify
+behavior changes manually (run the service, exercise it with the `curl`
+commands in `run.sh` / the Swagger UI).
+
+```bash
+mvn clean install          # from ussd-proxy-service/, builds the jar
+mvn spring-boot:run          # runs the app directly (reads application.properties)
+```
+
+Docker build (from `ussd-proxy-service/deploy/`, matching
+`deploy/build-docker.sh`):
+
+```bash
+cp ../target/*.jar .
+docker build -t mosip.io/ussdproxy .
+```
+
+The `deploy/Dockerfile` copies the fat jar in and runs it directly:
+
+```dockerfile
+ENTRYPOINT ["java","-jar","/app.jar"]
+```
+
+If you ever need to add a JVM system property to that entrypoint, `-D`
+flags must come **before** `-jar`, e.g. `java -Dspring.profiles.active=prod
+-jar /app.jar` — not after.
+
+`run.sh` (both the one at the project root and `deploy/run.sh`) isn't a
+startup script — it's a pair of `curl` calls against an already-running
+instance that register the USSD setup and a test partner:
+
+```bash
+curl -X POST "http://localhost/AT/ussd/setup" -H "accept: */*"
+curl -X POST "http://localhost/ussd/partner/" -H "accept: */*" \
+  -H "Content-Type: application/json" \
+  -d '{"partnerId":"1000","partnerUrl":"http://localhost:8080/credentials/","partnerKey":"abc123"}'
+```
+
+## Configuration
+
+`src/main/resources/application.properties` holds all runtime
+configuration: server port (`server.port=80`), Emnify callback/API
+settings, the MOSIP `mosip.appId` / `mosip.clientId` / `mosip.clientSecret`
+/ `mosip.baseUrl` used to call MOSIP APIs, and the H2 datasource.
+
+**This file, as checked into the repo, already contains non-placeholder-
+looking values** — an `emnify.apikey` JWT and a `mosip.clientSecret` — not
+just example/blank placeholders. Treat that as a known issue in this
+project, not a pattern to follow: do not add further real credentials to
+`application.properties`, and if you're setting up your own environment,
+override these via Spring's usual mechanisms (environment variables,
+`-D` system properties before `-jar`, or a profile-specific properties
+file) rather than editing the committed values in place.
+
+There is no separate `.env.example` or secrets-management convention in
+this project — it's all in the one properties file.
+
+## Project Structure Notes
+
+```text
+ussd-proxy-service/
+├── pom.xml
+├── run.sh                        # curl smoke-test commands, not a launcher
+├── deploy/
+│   ├── Dockerfile                  # java -jar entrypoint, EXPOSE 80
+│   ├── build-docker.sh              # copies target/*.jar in, then docker build
+│   ├── run-docker.sh                 # same curl smoke tests as run.sh
+│   └── run.sh
+└── src/main/
+    ├── java/org/mosip/ussd/
+    │   ├── IdServiceProvider/          # Calls to Resident APIs (IDSAPI) and Mimoto (IDCredsAPI)
+    │   ├── controller/                  # USSDController, PartnerController, EMnifyController
+    │   ├── dialog/                       # UssdMenu, UssdDialogEmnify — menu rendering
+    │   ├── emnify/                        # Emnify gateway integration
+    │   ├── sm/                             # State-machine engine: SMProcessor, SMAction, actions/*
+    │   ├── service/                         # ResidentService, CredentialService, SessionService, etc.
+    │   ├── storage/                          # Spring Data JPA repositories (H2-backed)
+    │   └── entity/, model/                    # JPA entities and DTOs
+    └── resources/
+        ├── application.properties
+        ├── en/menu.json, hi/menu.json          # Per-language USSD menu text
+        └── statemachine/sm.json                 # State machine definition (states, transitions, handlers)
+```
+
+To change USSD menu text, edit the relevant `resources/<lang>/menu.json`
+(currently English and Hindi are present, despite the README describing a
+French example — verify the actual language directories in
+`src/main/resources/` before assuming one exists). To change the flow
+itself (what happens after which input), edit `resources/statemachine/sm.json`
+and, if a new state needs custom logic, add a handler class under
+`sm/actions/` and wire it in per the existing handlers' pattern.
+
+## Development Workflow
+
+1. Set real values for `mosip.baseUrl`, `mosip.clientId`,
+   `mosip.clientSecret`, and the Emnify/Africa's Talking settings for your
+   target environment — don't rely on the values already committed in
+   `application.properties`, which point at specific dev/sandbox instances
+   and a real-looking secret.
+2. `mvn clean install` to build; `mvn spring-boot:run` (or run the built
+   jar) to start the service on port 80 (H2 file DB is created alongside
+   the jar as `./USSDDataBase`).
+3. Use the `curl` calls in `run.sh` to register the USSD setup and a test
+   partner before exercising the USSD flow end to end.
+4. There's no automated test suite — validate state-machine or handler
+   changes by walking the actual USSD menu (simulator or gateway sandbox)
+   through the affected path.
+
+## Pull Request Guidelines
+
+- Target `develop` (see repo-wide [`../AGENTS.md`](../AGENTS.md)).
+- This project has no CI wiring in `.github/workflows/` — no automated
+  build or Docker publish runs against it in this repo, so a passing local
+  `mvn clean install` is the only pre-merge signal; call out in the PR
+  description that you built and manually verified the change.
+- Do not add real credentials to `application.properties` as part of a PR,
+  even to "fix" the ones already there — flag it as a follow-up rather than
+  mixing a secrets-handling change into a functional one.
+
+## Repository-Specific Considerations
+
+- The project's Spring Boot version (2.3.12.RELEASE, from 2020) and Java
+  version (8) are noticeably older than other MOSIP services. Match the
+  existing style rather than upgrading dependencies or the Java version as
+  a side effect of an unrelated change.
+- Several dependencies in `pom.xml` are commented out (`db-util`, an
+  `emnify` SDK, Spring Data Redis/Jedis, Apache Derby) — these read as
+  abandoned experiments, not currently-wired functionality. Don't assume
+  code referencing them (if any) is live.
+- `emnify.callbackbase` in `application.properties` points at an ngrok
+  tunnel URL — this is a dev-only value that will not resolve in any other
+  environment; it must be overridden per deployment, not treated as a
+  working default.
+
+## Agent rules
+
+### Do
+
+1. Override `application.properties` values (MOSIP client credentials,
+   Emnify settings, callback URLs) per environment instead of relying on
+   the values already committed there.
+2. Put `-D` JVM system properties before `-jar` in any `java` command you
+   write or document.
+3. Add new USSD flow logic through the existing `sm/actions/` handler
+   pattern and register it in `statemachine/sm.json`.
+4. Verify changes manually (build + run + exercise the affected USSD path)
+   since there is no automated test suite here.
+
+### Do not
+
+1. Do not commit new real credentials or tokens into
+   `application.properties`.
+2. Do not upgrade the Java version or Spring Boot version as a side effect
+   of a functional change — treat that as a separate, deliberate decision.
+3. Do not assume commented-out dependencies (Redis/Jedis, the Emnify SDK,
+   Derby, `db-util`) are active — verify before building on them.
+4. Do not assume this project has CI, a Helm chart, or a test suite in this
+   repo — it has none of the three.

--- a/ussd-proxy-service/src/main/resources/application.properties
+++ b/ussd-proxy-service/src/main/resources/application.properties
@@ -5,7 +5,7 @@ emnify.callbackbase=https://c1da-197-156-69-51.ngrok-free.app
 emnify.endpointid=11772906
 emnify.serviceprofileid=458206
 emnify.baseurl=https://cdn.emnify.net/
-emnify.apikey=eyJhbGciOiJIUzM4NCJ9.eyJhdWQiOiJcL2FwaVwvdjFcL2FwcGxpY2F0aW9uX3Rva2VuIiwic3ViIjoic2FuYXRoQG1vc2lwLmlvIiwiZXNjLmFwcHNlY3JldCI6ImNjZDI5MDcwLTlkYmYtNDJkYy1hNjBkLTE4YTRmOGE5MzNiYSIsImVzYy5hcHAiOjg4NjYsImVzYy51c2VyIjoyMTk2MjMsImVzYy5vcmciOjE1Mjk5LCJlc2Mub3JnTmFtZSI6Ik1PU0lQIiwiaXNzIjoic3BjLWZyb250ZW5kMTAxQHNwYy1mcm9udGVuZCIsImlhdCI6MTY0NTcxMDQxNH0.RKwrowyznlke9pIOIzzw39vez62Jq_VoG1vM9Zaht4hivRelS64VYTqsMvD6Kcld
+emnify.apikey=${EMNIFY_APIKEY:}
 
 #MEC2 Configurations
 #mosip.appId=mosip-resident-client
@@ -13,15 +13,15 @@ emnify.apikey=eyJhbGciOiJIUzM4NCJ9.eyJhdWQiOiJcL2FwaVwvdjFcL2FwcGxpY2F0aW9uX3Rva
 # PREVIOUSLY EXISTING **********
 # mosip.appId=admin
 # mosip.clientId=mosip-resident-client
-# mosip.clientSecret=SnQLOIAnzya6AJXg
+# mosip.clientSecret=<set via MOSIP_CLIENT_SECRET>
 
 # mosip.appId=regproc
 # mosip.clientId=mosip-regproc-client
-# mosip.clientSecret=LHq4rivAsekR2ang
+# mosip.clientSecret=<set via MOSIP_CLIENT_SECRET>
 
 mosip.appId=resident
 mosip.clientId=mosip-resident-client
-mosip.clientSecret=te5kxlZcI9xLVOIE
+mosip.clientSecret=${MOSIP_CLIENT_SECRET:}
 
 #UIN=5163410279
 


### PR DESCRIPTION
Addresses https://github.com/mosip/mosip-config/issues/10670 — adds a root hub AGENTS.md plus per-project AGENTS.md files for AI coding assistants working in this repo.

## Summary

`mosip-labs` is a grab-bag of three independent experimental projects, not a single service, so this uses a tree pattern:

- `AGENTS.md` (root) — hub index: overview of all three projects, repo-wide CI/branching/PR notes, links to each project guide.
- `github-activity-tracker/AGENTS.md` — new guide (backend + frontend, build/config/CI).
- `ussd-proxy-service/AGENTS.md` — new guide (Maven/Spring Boot service, including a flag on the non-placeholder credentials already checked into `application.properties`).
- `MosipNexus/` already has its own `AGENTS.md` tree (root + `Server/` + `UI/`) — the root file links to it instead of duplicating it.

## Test plan

- [x] Verified every claim (build commands, CI trigger paths, config files) against the actual README/`pom.xml`/`package.json`/`.github/workflows/*` content in this repo.
- [x] Every fenced code block has a language tag (markdownlint MD040).
- [x] JVM `-D` guidance in `ussd-proxy-service/AGENTS.md` places system properties before `-jar`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added repository-wide development guidance covering project structure, build and test commands, configuration, secret handling, CI workflows, and pull-request practices.
  * Added project-specific guidance for the GitHub Activity Tracker and USSD Proxy Service, including architecture, Docker usage, migrations, deployment, development workflows, and verification procedures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->